### PR TITLE
Remove the LifecycleOwner from the map of registries after it is destroyed

### DIFF
--- a/framework/android/kodein-di-framework-android-support/src/main/java/org/kodein/di/android/support/scopes.kt
+++ b/framework/android/kodein-di-framework-android-support/src/main/java/org/kodein/di/android/support/scopes.kt
@@ -33,6 +33,7 @@ open class AndroidLifecycleScope private constructor(private val repositoryType:
                         fun onDestroy() {
                             owner.lifecycle.removeObserver(this)
                             registry.clear()
+                            map.remove(owner)
                         }
                     })
                     registry

--- a/framework/android/kodein-di-framework-android-x/src/main/java/org/kodein/di/android/x/scopes.kt
+++ b/framework/android/kodein-di-framework-android-x/src/main/java/org/kodein/di/android/x/scopes.kt
@@ -33,6 +33,7 @@ open class AndroidLifecycleScope private constructor(private val repositoryType:
                         fun onDestroy() {
                             owner.lifecycle.removeObserver(this)
                             registry.clear()
+                            map.remove(owner)
                         }
                     })
                     registry


### PR DESCRIPTION
Fixes #143 