### PR TITLE
fix typo on document example

### DIFF
--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -320,7 +320,7 @@ If you are using injection, you can pass the argument the exact same way:
 .Example: binding the Presenter class with injection
 ----
 val kodein = Kodein {
-    bind<Presenter>() with singleton { Presenter(instance(), inetance()) }
+    bind<Presenter>() with singleton { Presenter(instance(), instance()) }
 }
 ----
 


### PR DESCRIPTION
There is mistake in example in getting started document