### PR TITLE
Fix for bug getting cached instances with translated contexts

### DIFF
--- a/demo/demo-android/src/main/java/kodein/di/demo/MainFragment.kt
+++ b/demo/demo-android/src/main/java/kodein/di/demo/MainFragment.kt
@@ -38,6 +38,8 @@ class MainFragment : Fragment(), KodeinAware {
     override fun onStart() {
         super.onStart()
 
+        if (coffeeMaker != (requireActivity() as MainActivity).coffeeMaker) throw AssertionError()
+
         log.callback = {
             text.text = log.text
         }

--- a/demo/demo-android/src/main/java/kodein/di/demo/MainFragment.kt
+++ b/demo/demo-android/src/main/java/kodein/di/demo/MainFragment.kt
@@ -35,8 +35,8 @@ class MainFragment : Fragment(), KodeinAware {
         return inflater.inflate(R.layout.fragment_main, container, false)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
+    override fun onStart() {
+        super.onStart()
 
         log.callback = {
             text.text = log.text
@@ -51,5 +51,10 @@ class MainFragment : Fragment(), KodeinAware {
         Handler().postDelayed({
             coffeeMaker.brew()
         }, 6000)
+    }
+
+    override fun onStop() {
+        log.callback = null
+        super.onStop()
     }
 }

--- a/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinTreeImpl.kt
+++ b/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinTreeImpl.kt
@@ -152,8 +152,8 @@ internal class KodeinTreeImpl(
 
         val result = findBySpecs(SearchSpecs(key.contextType, key.argType, key.type, key.tag))
         if (result.size == 1) {
-            val (realKey, _) = result.first()
-            _cache[key] = _cache[realKey] ?: throw notInMap(realKey, key)
+            val (realKey, translator) = result.first()
+            _cache[key] = _cache[realKey]?.copy(third = translator) ?: throw notInMap(realKey, key)
         }
 
         return result.mapNotNull { (realKey, translator) ->


### PR DESCRIPTION
I found a bug in the Android demo project, where on first load, MainFragment's coffeeMaker was the same instance as MainActivity's, but on Activity restarts the MainFragment would end up creating a new CoffeeMaker instance instead of using the Activity's version.

See dcdbe9f for a demonstration of this effect.

The underlying problem was that the translator wasn't being cached when the Fragment finds the CoffeeMaker the first time. Fix in ad14180.

There was also a minor issue in the Android demo where the app would crash on rotate due to a view memory leak, which I fixed in 1a2530b.