### PR TITLE
Bug fixes related to context translation

### DIFF
--- a/kodein-di-core/src/commonMain/kotlin/org/kodein/di/Kodein.kt
+++ b/kodein-di-core/src/commonMain/kotlin/org/kodein/di/Kodein.kt
@@ -83,15 +83,18 @@ interface Kodein : KodeinAware {
          */
         private var _hashCode: Int = 0
 
-        /** @suppress */
         override fun hashCode(): Int {
             if (_hashCode == 0) {
                 _hashCode = contextType.hashCode()
                 _hashCode = 31 * _hashCode + argType.hashCode()
-                _hashCode = 29 * type.hashCode()
+                _hashCode = 29 * _hashCode + type.hashCode()
                 _hashCode = 23 * _hashCode + (tag?.hashCode() ?: 0)
             }
             return _hashCode
+        }
+
+        override fun equals(other: Any?): Boolean {
+            return other is Key<*,*,*> && hashCode() == other.hashCode()
         }
 
         /**

--- a/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinTreeImpl.kt
+++ b/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinTreeImpl.kt
@@ -128,7 +128,7 @@ internal class KodeinTreeImpl(
                 val anyContextKey = key.copy(contextType = AnyToken)
                 _cache[anyContextKey]?.let { triple ->
                     val (realKey, list, translator) = triple
-                    if ((translator != null && translator.contextType != key.contextType) || (translator == null && realKey.contextType != key.contextType ))
+                    if ((translator != null && translator.contextType != key.contextType))
                         return@let
                     _cache[key] = triple
                     val definition = list.getOrNull(overrideLevel) ?: return emptyList()


### PR DESCRIPTION
I've discovered a bug (or two?) in certain context translations. Consider this example:

We have the concept of a session that tracks information about the current user, so we make a scope for classes attached to a session. Classes where a session is required can be session scoped.

```kotlin
data class Session(val username: String)

object SessionScope : Scope<Session> {

    private var session: Session? = null
    private val registry = StandardScopeRegistry()

    fun beginSession(session: Session) {
        this.session = session
        registry.clear()
    }

    fun endSession() {
        this.session = null
        registry.clear()
    }

    fun requireSession(): Session = session!!

    override fun getRegistry(context: Session): ScopeRegistry = registry
}
```

We can use a context finder so that if a binding is requested from a different context, we can essentially assert that the session is active and use it to construct the service: `registerContextFinder { SessionScope.requireSession() }`

For this example we have two bindings, one for a session-scoped class and one for a general class anyone can bind:

```kotlin
class Logger(val tag: String) {
    fun log(message: String) {
        println("$tag : $message")
    }
}

class ScopedService(val session: Session, val logger: Logger) {
    fun logCurrentUser() {
        logger.log("the current user is ${session.username}")
    }
}
```

Consider this order of events:

```kotlin
object Demonstration {

    val logger: Logger by kodein.instance()

    fun run() {
        // logger.log("before session") // if we uncomment this, it will work

        SessionScope.beginSession(Session("joe"))

        kodein.direct.instance<ScopedService>().logCurrentUser()

        SessionScope.endSession()

        logger.log("after session") // crashes at SessionScope.requireSession() for trying to translate the context to a Session context
    }
}
```

The `Logger` is a provider binding, so anyone can make their own copy. Because the `ScopedService` binds its own logger, it adds a binding to the cache for `bind<Logger>() with ?<Session>().? { ? }`. Then when we go looking for a binding for `bind<Logger>() with ?<Demonstration>().? { ? }` it ends up matching the session-scoped binding instead of the generic one, and asking for a session context when none is required.

The first commit 24cb788 I'm pretty confident on. It looks like a typo in `Key::hashCode()` combined with the fact that equals was not defined was causing `(bind<Logger>() with ?<Session>().? { ? }).hashCode() == (bind<Logger>() with ?<Demonstration>().? { ? }).hashCode()` but `(bind<Logger>() with ?<Session>().? { ? }) != (bind<Logger>() with ?<Demonstration>().? { ? })`.

That alone didn't fix this particular issue though. Now a mapping for `bind<Logger>() with ? { ? }` is found in the cache, but [the second part of this conditional](https://github.com/Kodein-Framework/Kodein-DI/blob/6.2.0/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinTreeImpl.kt#L131) fails to select it.

This is the part of this PR I am less sure of. On one hand, the second conditional will *never* pass as far as I can tell, because `realKey.contextType` is always `AnyToken` but we already know `key.contextType != AnyToken`. On the other hand, this gets into some sensitive ordering of binding matching. In this case, I want the any-context binding to match first. But what if in other situations I do want a context-specific binding to match first? Does Kodein have a well-defined rule for the order in which bindings are matched?

I'm happy to add tests for this if you want.