### PR TITLE
fix ktor test failure

### DIFF
--- a/demo/demo-ktor/src/main/kotlin/KodeinApplication.kt
+++ b/demo/demo-ktor/src/main/kotlin/KodeinApplication.kt
@@ -11,7 +11,6 @@ import io.ktor.sessions.*
 import kotlinx.html.*
 import org.kodein.di.generic.*
 import org.kodein.di.ktor.*
-import java.security.*
 import java.util.*
 
 //region APP starter
@@ -21,8 +20,8 @@ fun main(args: Array<String>) {
         install(CallLogging)
 
         kodein {
-            bind<Random>() with scoped(SessionScope).singleton { SecureRandom() }
-            bind<Random>() with scoped(CallScope).singleton { SecureRandom() }
+            bind() from scoped(SessionScope).singleton { Random() }
+            bind() from scoped(CallScope).singleton { Random() }
         }
 
         sessionModule()

--- a/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorApplication.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorApplication.kt
@@ -8,7 +8,6 @@ import io.ktor.routing.*
 import io.ktor.sessions.*
 import org.kodein.di.*
 import org.kodein.di.generic.*
-import java.security.*
 import java.util.*
 
 // Test Ktor Application
@@ -16,8 +15,8 @@ fun Application.main() {
     install(DefaultHeaders)
 
     kodein {
-        bind<Random>() with scoped(SessionScope).singleton { SecureRandom() }
-        bind<Random>() with scoped(CallScope).singleton { SecureRandom() }
+        bind() from scoped(SessionScope).singleton { Random() }
+        bind() from scoped(CallScope).singleton { Random() }
 
         constant("author") with AUTHOR.toLowerCase()
     }

--- a/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorTests.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorTests.kt
@@ -30,7 +30,7 @@ class KtorTests {
         handleRequest(HttpMethod.Get, ROUTE_SESSION).apply {
             val content = response.content
             assertNotNull(content)
-            assertContained("java.security.SecureRandom@.*".toRegex(), content)
+            assertContained("java.util.Random@.*".toRegex(), content)
         }
     }
 


### PR DESCRIPTION
Binding a `java.security.SecureRandom` give a `NonBlocking` at retrieval in Ktor pipeline (=coroutine).

Moving to `java.util.Random` fix the issue.

Maybe an other inspiration to go for Kodein-DI coroutine compatibility ?