### PR TITLE
ktor fix failing test_03_session_scoped

### DIFF
--- a/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorTests.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorTests.kt
@@ -94,7 +94,8 @@ class KtorTests {
                         .first { it.name == SESSION_FEATURE_SESSION_ID }
 
                 assertNotNull(cookie)
-                assertEquals(sessionCookie, cookie)
+                assertEquals(sessionCookie.name, cookie.name)
+                assertEquals(sessionCookie.value, cookie.value)
             }
 
             // (5) Call '/session' with the session MockSession(counter=2)


### PR DESCRIPTION
avoid time lag between to API calls as we were comparing session, expiration timestamps can have interval. 