### PR TITLE
Modifying Ktor routing with KodeinController

### DIFF
--- a/doc/ktor.adoc
+++ b/doc/ktor.adoc
@@ -406,7 +406,7 @@ NOTE:  the `kodein-di-framework-ktor-server-controller-jvm` already have  the `k
 
 -  Defining your controllers, by implementing `KodeinController`, or extending `AbstractKodeinController`
 + 
-To define your controllers you need, either to implement the interface `KodeinController`, or to extend the class `AbstractKodeinController` and implement the function `Routing.installRoutes()`.
+To define your controllers you need, either to implement the interface `KodeinController`, or to extend the class `AbstractKodeinController` and implement the function `Route.getRoutes()`.
 +
 [source, kotlin]
 .Example: Implementing KodeinController
@@ -415,7 +415,7 @@ class MyController(application: Application) : KodeinController { <1>
     override val kodein by kodein { application } <2>
     private val repository: DataRepository by instance("dao") <3>
 
-    override fun Routing.installRoutes() { <4>
+    override fun Route.getRoutes() { <4>
         get("/version") { <5>
             val version: String by instance("version") <8>
             call.respondText(version)
@@ -425,7 +425,7 @@ class MyController(application: Application) : KodeinController { <1>
 <1> Implement `KodeinController` and provide a `Application` instance (from constructor)
 <2> Override the `Kodein` container, from the provided `Application`
 <3> Use your `Kodein` container as in any `KodeinAware` class
-<4> Override the function `Routing.installRoutes` and define some routes
+<4> Override the function `Route.getRoutes` and define some routes
 <5> This route will be automatically register by the `KodeinControllerFeature`
 <6> Use your `Kodein` container as in any `KodeinAware` class
 +
@@ -454,9 +454,9 @@ NOTE:   Using `KodeinController` or `AbstractKodeinController` depends on your n
         +
         On the contrary, if you want to use inheritance for your controllers you should implement `KodeinController` and override the `Kodein` container by yourself. 
 
-- Declaring the `KodeinControllerFeature`
+- Declaring the `KodeinControllerFeature` (deprecated in `6.4`, removed in `7.0`)
 +
-To benefit from the `KodeinController` behavior, you *need* to use the `KodeinControllerFeature` that will install the routes of your `KodeinController`s.
+To benefit from the `KodeinController` behavior, you *could* use the `KodeinControllerFeature` that will install the routes of your `KodeinController`s.
 +
 The `KodeinControllerFeature` will work upon the `KodeinFeature`, registering all the `KodeinController` bound in it. 
 + 
@@ -478,8 +478,37 @@ fun main(args: Array<String>) {
 <3> Bind a `KodeinController`
 <4> Apply the `KodeinControllerFeature`
 +
-Doing that the `MyController` will be autowired by the `KodeinControllerFeature`, meaning that the routes defined in the `Routing.installRoutes` will be reachable on the web server (e.g. `http://localhost:8080/version`).
+Doing that the `MyController` will be autowired by the `KodeinControllerFeature`, meaning that the routes defined in the `Route.getRoutes` will be reachable on the web server (e.g. `http://localhost:8080/version`).
 
 WARNING: Using the `KodeinControllerFeature` *must* be used in addition of the `KodeinFeature`
 
 WARNING: In your code, the `KodeinControllerFeature` *must* be declared *after* the `KodeinFeature`, as in the previous snippet *4* is declared after *1*, unless you'll see a `MissingApplicationFeatureException` fired
+
+- Install your `KodeinController`s routes directly into the routing system
++
+To leverage the use of `KodeinController`, you *could* use the `Route.controller` extension functions.
+Those functions will automatically install the routes defined in your `KodeinController` into the Ktor routing system.
++
+[source, kotlin]
+.Example: Route.controller extension functions
+----
+routing {
+// ...
+controller { MyFirstKodeinController(instance()) } <1>
+controller("/protected") { `MySecondKodeinController`(instance()) } <2>
+// ...
+}
+----
+<1> install the routes of MyFirstKodeinController` inside the routing system
+<2> install the routes of `MyFirstKodeinController` inside the routing system, as child of a `Route`, under "/protected"
++
+Doing that the `MyFirstKodeinController` and `MyFirstKodeinController` will added to the routing system but not autowired, neither bound to the Kodein container.
+Only their routes defined in the `Route.getRoutes` will be reachable on the web server (e.g. `http://localhost:8080/version`).
+
+
+[CAUTION]
+====
+`Route.controller` extension functions and `KodeinControllerFeature` can be used at the same time but we recommand that you *should not*
+Declaring controllers in the `Route.controller` extension functions and the `KodeinControllerFeature` might install the same route multiple times, thus leading to exceptions.
+====
+

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/controller.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/controller.kt
@@ -3,14 +3,14 @@ package org.kodein.di.ktor.controller
 import io.ktor.application.*
 import io.ktor.routing.*
 import org.kodein.di.*
-import org.kodein.di.ktor.kodein
+import org.kodein.di.ktor.*
 
 /**
  * Base controller super class to leverage your Ktor server as a MVC-like architecture
  *
  * Example:
  * class ApplicationController(application: Application) : AbstractKodeinController(application) {
- *    override fun Routing.installRoutes() {
+ *    override fun Route.getRoutes() {
  *      route(ROUTE_VERSION) {
  *      get {
  *        val version: String by instance("version")
@@ -30,7 +30,7 @@ abstract class AbstractKodeinController(val application: Application) : KodeinCo
  * Example:
  * class KodeinControllerImpl(application: Application) : KodeinController(application) {
  *    override val kodein by kodein { application }
- *    override fun Routing.installRoutes() {
+ *    override fun Route.getRoutes() {
  *      route(ROUTE_VERSION) {
  *      get {
  *        val version: String by instance("version")
@@ -42,7 +42,15 @@ abstract class AbstractKodeinController(val application: Application) : KodeinCo
  */
 interface KodeinController : KodeinAware {
     /**
-     * Define the routes that may be applied by installing [KodeinControllerFeature]
+     * Define the getRoutes that may be applied by installing [KodeinControllerFeature]
      */
-    fun Routing.installRoutes()
+    fun Routing.installRoutes() = getRoutes()
+    /**
+     * Install the controller's routes into the [Routing] feature
+     */
+    fun Route.installRoutes() = getRoutes()
+    /**
+     * Define the routes that may be applied into the [Routing] feature
+     */
+    fun Route.getRoutes()
 }

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/controller.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/controller.kt
@@ -44,6 +44,9 @@ interface KodeinController : KodeinAware {
     /**
      * Define the getRoutes that may be applied by installing [KodeinControllerFeature]
      */
+    // Deprecated Since 6.4
+    @Deprecated(message = "As [KodeinControllerFeature] will be deprectated we will not need this anymore",
+            replaceWith = ReplaceWith("Route.installRoutes()"), level = DeprecationLevel.WARNING)
     fun Routing.installRoutes() = getRoutes()
     /**
      * Install the controller's routes into the [Routing] feature

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/exentsions.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/exentsions.kt
@@ -1,0 +1,29 @@
+package org.kodein.di.ktor.controller
+
+import io.ktor.routing.*
+import io.ktor.util.pipeline.*
+import org.kodein.di.*
+import org.kodein.di.ktor.*
+
+
+/**
+ * Allow to install a [KodeinController] and defined [Route]s into the routing system
+ * e.g. Route.controller { KodeinControllerImpl() }
+ */
+@ContextDsl
+fun Route.controller(init: DKodein.() -> KodeinController) = run {
+    val kodeinController by kodein().newInstance { init() }
+    kodeinController.apply { installRoutes() }
+}
+
+/**
+ * Allow to install a [KodeinController] and defined [Route]s into the routing system
+ * inside a specific route
+ * e.g. Route.controller("/protected") { KodeinControllerImpl() }
+ */
+@ContextDsl
+fun Route.controller(endpoint: String, init: DKodein.() -> KodeinController) = run {
+    route(endpoint){
+        controller(init)
+    }
+}

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/feature.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/main/kotlin/org/kodein/di/ktor/controller/feature.kt
@@ -4,15 +4,18 @@ import io.ktor.application.*
 import io.ktor.routing.*
 import io.ktor.util.*
 import org.kodein.di.*
-import org.kodein.di.ktor.KodeinFeature
+import org.kodein.di.ktor.*
 import org.kodein.di.ktor.controller.KodeinControllerFeature.*
-import org.kodein.di.ktor.kodein
 
 /**
  * Ktor [Feature] that provide a global [Kodein] container
  * and autowire all the bound [AbstractKodeinController] by installing the routes
  * that would be accessible from everywhere in the Ktor application
  */
+// Deprecated Since 6.4
+@Deprecated(message="KodeinController doesn't need to be bound to the Kodein container. " +
+        "\nConsider using the [Route.controller] method (e.g. `Route.controller { KodeinController() }`)" +
+        "\nWill be remove in 7.0", level = DeprecationLevel.WARNING)
 class KodeinControllerFeature private constructor() {
 
     // Implements ApplicationFeature as a companion object.

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/test/kotlin/org/kodein/di/ktor/controller/KtorApplication.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/test/kotlin/org/kodein/di/ktor/controller/KtorApplication.kt
@@ -2,8 +2,9 @@ package org.kodein.di.ktor.controller
 
 import io.ktor.application.*
 import io.ktor.features.*
+import io.ktor.routing.*
 import org.kodein.di.generic.*
-import org.kodein.di.ktor.kodein
+import org.kodein.di.ktor.*
 
 const val AUTHOR = "Romain Boisselle"
 const val VERSION = "1.0.0"
@@ -36,4 +37,27 @@ fun Application.kodeincontrollerImplFailure() {
     install(DefaultHeaders)
     install(KodeinControllerFeature)
     installKodein()
+}
+
+fun Application.kodeinControllerSuccess() {
+    install(DefaultHeaders)
+    installKodein()
+    routing {
+
+        controller { KodeinControllerImpl(instance()) }
+
+        route("/first") {
+            controller { KodeinControllerImpl(instance()) }
+
+            route("/second") {
+                controller { ApplicationController(instance()) }
+
+                route("/third") {
+                    controller { ApplicationController(instance()) }
+                }
+            }
+        }
+
+        controller("/protected") { KodeinControllerImpl(instance()) }
+    }
 }

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/test/kotlin/org/kodein/di/ktor/controller/KtorControllerTests.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/test/kotlin/org/kodein/di/ktor/controller/KtorControllerTests.kt
@@ -3,9 +3,9 @@ package org.kodein.di.ktor.controller
 import io.ktor.application.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
-import org.junit.FixMethodOrder
+import org.junit.*
 import org.junit.Test
-import org.junit.runners.MethodSorters
+import org.junit.runners.*
 import kotlin.test.*
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -41,6 +41,46 @@ class KtorControllerTests {
     fun test_03_failureKodeinControllerImplFeature() {
         assertFailsWith(MissingApplicationFeatureException::class) {
             withTestApplication(Application::kodeincontrollerImplFailure) {}
+        }
+    }
+
+    @Test
+    fun test_00_successKodeinControllerAutoConfiguration(): Unit = withTestApplication(Application::kodeinControllerSuccess) {
+
+        val ROUTE_PROTECTED = "/protected"
+        val ROUTE_FIRST = "/first"
+        val ROUTE_SECOND = "$ROUTE_FIRST/second"
+        val ROUTE_THIRD = "$ROUTE_SECOND/third"
+
+        handleRequest(HttpMethod.Get, ROUTE_VERSION).apply {
+            assertEquals(VERSION, response.content)
+        }
+        handleRequest(HttpMethod.Get, ROUTE_AUTHOR).apply {
+            assertEquals(AUTHOR, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_FIRST$ROUTE_VERSION").apply {
+            assertEquals(VERSION, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_FIRST$ROUTE_AUTHOR").apply {
+            assertEquals(AUTHOR, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_SECOND$ROUTE_VERSION").apply {
+            assertEquals(VERSION, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_SECOND$ROUTE_AUTHOR").apply {
+            assertEquals(AUTHOR, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_THIRD$ROUTE_VERSION").apply {
+            assertEquals(VERSION, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_THIRD$ROUTE_AUTHOR").apply {
+            assertEquals(AUTHOR, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_PROTECTED$ROUTE_VERSION").apply {
+            assertEquals(VERSION, response.content)
+        }
+        handleRequest(HttpMethod.Get, "$ROUTE_PROTECTED$ROUTE_AUTHOR").apply {
+            assertEquals(AUTHOR, response.content)
         }
     }
 }

--- a/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/test/kotlin/org/kodein/di/ktor/controller/controller.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-controller-jvm/src/test/kotlin/org/kodein/di/ktor/controller/controller.kt
@@ -10,7 +10,7 @@ const val ROUTE_VERSION = "/version"
 const val ROUTE_AUTHOR = "/author"
 
 class ApplicationController(application: Application) : AbstractKodeinController(application) {
-    override fun Routing.installRoutes() {
+    override fun Route.getRoutes() {
         route(ROUTE_VERSION) {
             get {
                 val version: String by instance("version")
@@ -28,7 +28,7 @@ class ApplicationController(application: Application) : AbstractKodeinController
 
 class KodeinControllerImpl(application: Application) : KodeinController {
     override val kodein by kodein { application }
-    override fun Routing.installRoutes() {
+    override fun Route.getRoutes() {
         route(ROUTE_VERSION) {
             get {
                 val version: String by instance("version")


### PR DESCRIPTION
> Following the issue #206 

### `Route.controller` extension functions

Adding two extension functions to be able to install `KodeinController` routes inside the Ktor routing system.

> Allowing us to write
```kotlin
routing {
    controller { FirstController(instance()) }

    route {
        controller { SecondController(instance()) }
    }

    authenticate("name") {
        controller("/protected") { KodeinControllerImpl(instance()) }
    }
}
```

### `KodeinControllerFeature` depreciation

As the `KodeinController` might always be singletons, the new extension functions cover all we need, without extra work.
So, I suggest to deprecate `KodeinControllerFeature` as we don't need to bind `KodeinController` inside Kodein.