### PR TITLE
Allow extended container to use imported modules

### DIFF
--- a/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinBuilderImpl.kt
+++ b/kodein-di-core/src/commonMain/kotlin/org/kodein/di/internal/KodeinBuilderImpl.kt
@@ -6,7 +6,7 @@ import org.kodein.di.bindings.*
 internal open class KodeinBuilderImpl internal constructor(
         private val moduleName: String?,
         private val prefix: String,
-        private val importedModules: MutableSet<String>,
+        internal val importedModules: MutableSet<String>,
         override val containerBuilder: KodeinContainerBuilderImpl
 ) : Kodein.Builder {
 
@@ -81,6 +81,11 @@ internal open class KodeinMainBuilderImpl(allowSilentOverride: Boolean) : Kodein
 
         containerBuilder.extend(kodein.container, allowOverride, keys)
         externalSources += kodein.container.tree.externalSources
+        importedModules.addAll(
+                containerBuilder.bindingsMap
+                        .flatMap { it.value.map { it.fromModule } }
+                        .filterNotNull()
+        )
     }
 
     override fun extend(dkodein: DKodein, allowOverride: Boolean, copy: Copy) {
@@ -88,5 +93,10 @@ internal open class KodeinMainBuilderImpl(allowSilentOverride: Boolean) : Kodein
 
         containerBuilder.extend(dkodein.container, allowOverride, keys)
         externalSources += dkodein.container.tree.externalSources
+        importedModules.addAll(
+                containerBuilder.bindingsMap
+                        .flatMap { it.value.map { it.fromModule } }
+                        .filterNotNull()
+        )
     }
 }

--- a/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_10_Module.kt
+++ b/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_10_Module.kt
@@ -1,10 +1,7 @@
 package org.kodein.di.erased
 
-import org.kodein.di.Kodein
-import org.kodein.di.direct
-import org.kodein.di.test.FixMethodOrder
-import org.kodein.di.test.MethodSorters
-import org.kodein.di.test.Person
+import org.kodein.di.*
+import org.kodein.di.test.*
 import kotlin.test.*
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -75,4 +72,30 @@ class ErasedTests_10_Module {
         assertEquals("Salomon", kodein.direct.instance())
     }
 
+    @Test
+    fun test_03_ModuleOverExtend() {
+        val salomon = "Salomon"
+        val module = Kodein.Module("test") {
+            bind<String>() with instance(salomon)
+        }
+
+        val container1 = Kodein {
+            importOnce(module)
+        }
+
+        val container2 = Kodein {
+            extend(container1)
+            importOnce(module)
+        }
+
+        val container3 = Kodein {
+            extend(container2)
+            importOnce(module)
+        }
+
+        assertEquals(salomon, container1.direct.instance())
+        assertEquals(salomon, container2.direct.instance())
+        assertEquals(salomon, container3.direct.instance())
+        assertSame(container1.direct.instance<String>(), container2.direct.instance(), container3.direct.instance())
+    }
 }

--- a/kodein-di-generic-jvm/src/test/kotlin/org/kodein/di/generic/GenericJvmTests_10_Module.kt
+++ b/kodein-di-generic-jvm/src/test/kotlin/org/kodein/di/generic/GenericJvmTests_10_Module.kt
@@ -1,10 +1,7 @@
 package org.kodein.di.generic
 
-import org.kodein.di.Kodein
-import org.kodein.di.direct
-import org.kodein.di.test.FixMethodOrder
-import org.kodein.di.test.MethodSorters
-import org.kodein.di.test.Person
+import org.kodein.di.*
+import org.kodein.di.test.*
 import kotlin.test.*
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -75,5 +72,30 @@ class GenericJvmTests_10_Module {
         assertEquals("Salomon", kodein.direct.instance())
     }
 
+    @Test
+    fun test_03_ModuleOverExtend() {
+        val salomon = "Salomon"
+        val module = Kodein.Module("test") {
+            bind<String>() with instance(salomon)
+        }
 
+        val container1 = Kodein {
+            importOnce(module)
+        }
+
+        val container2 = Kodein {
+            extend(container1)
+            importOnce(module)
+        }
+
+        val container3 = Kodein {
+            extend(container2)
+            importOnce(module)
+        }
+
+        assertEquals(salomon, container1.direct.instance())
+        assertEquals(salomon, container2.direct.instance())
+        assertEquals(salomon, container3.direct.instance())
+        assertSame(container1.direct.instance<String>(), container2.direct.instance(), container3.direct.instance())
+    }
 }


### PR DESCRIPTION
When extending a container, we add to the `importedModules` of the current `MainBuilder` the modules of the copied bindings.

This is the more straightforward solution as we don't have the modules anynore, as long as the container as been built. We only have the reference name of the modules, in the bindings themself, through the var `KodeinDefining#fromModule`.
