### PR TITLE
Depreciate multi-argument factories

### DIFF
--- a/doc/core.adoc
+++ b/doc/core.adoc
@@ -370,6 +370,8 @@ val kodein = Kodein {
 [[multi-argument-factories]]
 ==== Multi-arguments factories
 
+CAUTION: This multi-agrument-factories mechanism is deprecated and will be removed in version `7.0`
+
 A factory can take multiple (up to 5) arguments:
 
 [source,kotlin]
@@ -377,6 +379,22 @@ A factory can take multiple (up to 5) arguments:
 ----
 val kodein = Kodein {
     bind<Dice>() with factory { startNumber: Int, sides: Int -> RandomDice(sides) }
+}
+----
+
+NOTE: We recommand to use `data classes` instead!
+
+Regarding our users feedbacks, we find out that multi-arguments factories was difficult to use.
+
+Thus this mechanism will be deprecate soon. So we highly recommend that you migrate your multi-args factories to simple factories by using *data classes*.
+
+[source,kotlin]
+.Example: creates a new Dice each time you need one, according to multiple parameters
+----
+data class DiceParams(val startNumber: Int, val sides: Int)
+
+val kodein = Kodein {
+    bind<Dice>() with factory { params: DiceParams -> RandomDice(params) }
 }
 ----
 
@@ -957,12 +975,14 @@ If you are not sure (or simply do not know) if the type has been bound, you can 
 
 ==== Multi-arguments factories
 
-When injecting a value that was bound with a <<multi-argument-factories,multi-argument factory>>, the arguments must be wrapped inside the `M` function:
+When injecting a value that was bound with a <<multi-argument-factories,multi-argument factory>>,
+the arguments must be wrapped inside a *data class*:
 
 [source, kotlin]
 .Example: Creating a FileController by injecting a multi-argument bound dependency.
 ----
-val controller by kodein.newInstance { FileController(instance(args = M("path/to/fil", 0))) }
+data class ControllerParams(val path: String, val timeout: Int)
+val controller by kodein.newInstance { FileController(instance(args = ControllerParams("path/to/file", 0))) }
 ----
 
 
@@ -982,12 +1002,13 @@ class RollController(val dice: Dice) { /*...*/ }
 val controller by kodein.newInstance { RollController(instance(arg = 6)) }
 ----
 
-Note that if you bound a factory with multiple argument, you need to use the `M` function to pass multiple arguments:
+Note that if you want to bind a factory with multiple argument, you need to use a *data class* to pass multiple arguments:
 
 [source, kotlin]
 .Example: Creating a multi-argument RollController by injecting its dependency.
 ----
-val controller by kodein.newInstance { RollController(instance(arg = M(60, 6))) }
+data class Params(val arg1: Int, val arg2: Int)
+val controller by kodein.newInstance { RollController(instance(arg = Params(60, 6))) }
 ----
 
 TIP: The `arg` argument should always be named.
@@ -1091,34 +1112,25 @@ val answer: String by kodein.named.instance()
 
 ==== Multi-arguments factories
 
-When retrieving a value that was bound with a <<multi-argument-factories,multi-argument factory>>, the arguments must be wrapped inside the `M` function:
+When retrieving a value that was bound with a <<multi-argument-factories,multi-argument factory>>, the arguments must be wrapped inside a *data class*:
 
 [source, kotlin]
 .Example: Creating a MainController by injecting a multi-argument bound dependency.
 ----
-val fileAccess: FileAccess by kodein.instance(args = M("/path/to/file", 0))
+data class FileParams(val path: String, val maxSize: Int)
+val fileAccess: FileAccess by kodein.instance(args = FileParams("/path/to/file", 0))
 ----
 
 ===== Factory retrieval
 
 Instead of retrieving a value, you can retrieve a factory, that can call as much as you need.
-As you can declare factories with multiple arguments (up to 5), you can retrieve factories with arguments from 1 to 5:
 
 [source, kotlin]
-.Example: Creating factories with multi-argument (from 1 to 5).
+.Example: Retrieving factory.
 ----
 val f1: (Int) -> Int by kodein.factory() <1>
-val f2: (Int, Int) -> Int by kodein.factory2() <2>
-val f3: (String, Int, Int) -> String by kodein.factory3() <3>
-val f4: (Int, Int, Int, Int) -> Int by kodein.factory4() <4>
-val f5: (String, Int, String, Int, String) -> String by kodein.factory5() <5>
 ----
 <1> retrieving a factory that takes 1 argument (Int) and return an Int
-<2> retrieving a factory that takes 2 argument (Int, Int) and return an Int
-<3> retrieving a factory that takes 3 argument (String, Int, Int) and return a String
-<4> retrieving a factory that takes 4 argument (Int, Int, Int, Int) and return an Int
-<5> retrieving a factory that takes 5 argument (String, Int, String, Int, String) and return an String
-
 
 ==== Currying factories
 
@@ -1131,12 +1143,13 @@ val sixSideDiceProvider: () -> Dice by kodein.provider(arg = 6)
 val twentySideDice: Dice by kodein.instance(arg = 20)
 ----
 
-Note that if you bound a factory with multiple arguments, you need to use the `M` function to pass multiple arguments:
+Note that if you bound a factory with multiple arguments, you need to use a *data class* to pass multiple arguments:
 
 [source, kotlin]
 .Example: Creating a multi-argument Dice by injecting its dependency.
 ----
-val sixtyToSixtySixDice: Dice by kodein.instance(arg = M(60, 6)) <1>
+data class DiceParams(val startNumber: Int, val sides: Int)
+val sixtyToSixtySixDice: Dice by kodein.instance(arg = DiceParams(60, 6)) <1>
 ----
 <1> Bonus points if you can say the variable name 5 times in less than 5 seconds ;)
 

--- a/kodein-di-core/src/commonMain/kotlin/org/kodein/di/tuples.kt
+++ b/kodein-di-core/src/commonMain/kotlin/org/kodein/di/tuples.kt
@@ -8,6 +8,11 @@ package org.kodein.di
  * @property a1 The first argument.
  * @property a2 The second argument.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 data class Multi2<A1, A2>(
         val a1: A1,
         val a2: A2,
@@ -28,6 +33,11 @@ data class Multi2<A1, A2>(
  * @property a2 The second argument.
  * @property a3 The third argument.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 data class Multi3<A1, A2, A3>(
         val a1: A1,
         val a2: A2,
@@ -51,6 +61,11 @@ data class Multi3<A1, A2, A3>(
  * @property a3 The third argument.
  * @property a4 The fourth argument.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 data class Multi4<A1, A2, A3, A4>(
         val a1: A1,
         val a2: A2,
@@ -80,6 +95,11 @@ data class Multi4<A1, A2, A3, A4>(
  * @property a4 The fourth argument.
  * @property a5 The fifth argument.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 data class Multi5<A1, A2, A3, A4, A5>(
         val a1: A1,
         val a2: A2,

--- a/kodein-di-erased/src/commonMain/kotlin/org/kodein/di/erased/EMulti.kt
+++ b/kodein-di-erased/src/commonMain/kotlin/org/kodein/di/erased/EMulti.kt
@@ -272,6 +272,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5> Multi5.C
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> KodeinAware.factory2(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi2<A1, A2            >, T>(Multi2.erased(), erased(), tag)) { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } }
 
@@ -289,6 +294,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> KodeinAware.factory3(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi3<A1, A2, A3        >, T>(Multi3.erased(), erased(), tag)) { { a1: A1, a2: A2, a3: A3                 -> it(M(a1, a2, a3        )) } }
 
@@ -307,6 +317,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> KodeinAware.factory4(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi4<A1, A2, A3, A4    >, T>(Multi4.erased(), erased(), tag)) { { a1: A1, a2: A2, a3: A3, a4: A4         -> it(M(a1, a2, a3, a4    )) } }
 
@@ -326,6 +341,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> KodeinAware.factory5(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi5<A1, A2, A3, A4, A5>, T>(Multi5.erased(), erased(), tag)) { { a1: A1, a2: A2, a3: A3, a4: A4, a5: A5 -> it(M(a1, a2, a3, a4, a5)) } }
 
@@ -343,6 +363,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> KodeinAware.factory2OrNull(tag: Any? = null): LazyDelegate<((A1, A2            ) -> T)?> {
     return KodeinPropertyMap(FactoryOrNull<Multi2<A1, A2            >, T>(Multi2.erased(), erased(), tag)) {
         val factory = it ?: return@KodeinPropertyMap null
@@ -364,6 +389,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> KodeinAware.factory3OrNull(tag: Any? = null): LazyDelegate<((A1, A2, A3        ) -> T)?> {
     return KodeinPropertyMap(FactoryOrNull<Multi3<A1, A2, A3        >, T>(Multi3.erased(), erased(), tag)) {
         val factory = it ?: return@KodeinPropertyMap null
@@ -386,6 +416,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> KodeinAware.factory4OrNull(tag: Any? = null): LazyDelegate<((A1, A2, A3, A4    ) -> T)?> {
     return KodeinPropertyMap(FactoryOrNull<Multi4<A1, A2, A3, A4    >, T>(Multi4.erased(), erased(), tag)) {
         val factory = it ?: return@KodeinPropertyMap null
@@ -409,6 +444,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> KodeinAware.factory5OrNull(tag: Any? = null): LazyDelegate<((A1, A2, A3, A4, A5) -> T)?> {
     return KodeinPropertyMap(FactoryOrNull<Multi5<A1, A2, A3, A4, A5>, T>(Multi5.erased(), erased(), tag)) {
         val factory = it ?: return@KodeinPropertyMap null
@@ -430,6 +470,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> DKodein.factory2(tag: Any? = null) =
         Factory<Multi2<A1, A2            >, T>(Multi2.erased(), erased(), tag).let { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } }
 
@@ -447,6 +492,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> DKodein.factory3(tag: Any? = null) =
         Factory<Multi3<A1, A2, A3        >, T>(Multi3.erased(), erased(), tag).let { { a1: A1, a2: A2, a3: A3                 -> it(M(a1, a2, a3        )) } }
 
@@ -465,6 +515,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> DKodein.factory4(tag: Any? = null) =
         Factory<Multi4<A1, A2, A3, A4    >, T>(Multi4.erased(), erased(), tag).let { { a1: A1, a2: A2, a3: A3, a4: A4         -> it(M(a1, a2, a3, a4    )) } }
 
@@ -484,6 +539,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> DKodein.factory5(tag: Any? = null) =
         Factory<Multi5<A1, A2, A3, A4, A5>, T>(Multi5.erased(), erased(), tag).let { { a1: A1, a2: A2, a3: A3, a4: A4, a5: A5 -> it(M(a1, a2, a3, a4, a5)) } }
 
@@ -503,7 +563,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified 
  */
 //inline fun <reified A1, reified A2,                                     reified T: Any> DKodein.factory2OrNull(tag: Any? = null) =
 //        FactoryOrNull<Multi2<A1, A2            >, T>(Multi2.erased(), erased(), tag).let { it?.let { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } } }
-
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> DKodein.factory2OrNull(tag: Any? = null): ((A1, A2            ) -> T)? {
     val factory = FactoryOrNull<Multi2<A1, A2            >, T>(Multi2.erased(), erased(), tag) ?: return null
     return { a1, a2             -> factory(M(a1, a2            )) }
@@ -523,6 +587,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> DKodein.factory3OrNull(tag: Any? = null): ((A1, A2, A3        ) -> T)? {
     val factory = FactoryOrNull<Multi3<A1, A2, A3        >, T>(Multi3.erased(), erased(), tag) ?: return null
     return { a1, a2, a3         -> factory(M(a1, a2, a3        )) }
@@ -543,6 +612,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> DKodein.factory4OrNull(tag: Any? = null): ((A1, A2, A3, A4    ) -> T)? {
     val factory = FactoryOrNull<Multi4<A1, A2, A3, A4    >, T>(Multi4.erased(), erased(), tag) ?: return null
     return { a1, a2, a3, a4     -> factory(M(a1, a2, a3, a4    )) }
@@ -565,6 +639,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> DKodein.factory5OrNull(tag: Any? = null): ((A1, A2, A3, A4, A5) -> T)? {
     val factory = FactoryOrNull<Multi5<A1, A2, A3, A4, A5>, T>(Multi5.erased(), erased(), tag) ?: return null
     return { a1, a2, a3, a4, a5 -> factory(M(a1, a2, a3, a4, a5)) }

--- a/kodein-di-erased/src/commonMain/kotlin/org/kodein/di/erased/EMulti.kt
+++ b/kodein-di-erased/src/commonMain/kotlin/org/kodein/di/erased/EMulti.kt
@@ -16,6 +16,11 @@ import org.kodein.di.bindings.*
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2,                                     reified T: Any> Kodein.BindBuilder.WithContext<C>.factory(noinline creator: BindingKodein<C>.(A1, A2            ) -> T) = Factory(contextType, Multi2.erased<A1, A2            >(), erased()) { creator(it.a1, it.a2                     ) }
 
 /**
@@ -32,6 +37,11 @@ inline fun <C, reified A1, reified A2,                                     reifi
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2, reified A3,                         reified T: Any> Kodein.BindBuilder.WithContext<C>.factory(noinline creator: BindingKodein<C>.(A1, A2, A3        ) -> T) = Factory(contextType, Multi3.erased<A1, A2, A3        >(), erased()) { creator(it.a1, it.a2, it.a3              ) }
 
 /**
@@ -49,6 +59,11 @@ inline fun <C, reified A1, reified A2, reified A3,                         reifi
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2, reified A3, reified A4,             reified T: Any> Kodein.BindBuilder.WithContext<C>.factory(noinline creator: BindingKodein<C>.(A1, A2, A3, A4    ) -> T) = Factory(contextType, Multi4.erased<A1, A2, A3, A4    >(), erased()) { creator(it.a1, it.a2, it.a3, it.a4       ) }
 
 /**
@@ -67,6 +82,11 @@ inline fun <C, reified A1, reified A2, reified A3, reified A4,             reifi
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> Kodein.BindBuilder.WithContext<C>.factory(noinline creator: BindingKodein<C>.(A1, A2, A3, A4, A5) -> T) = Factory(contextType, Multi5.erased<A1, A2, A3, A4, A5>(), erased()) { creator(it.a1, it.a2, it.a3, it.a4, it.a5) }
 
 
@@ -84,6 +104,11 @@ inline fun <C, reified A1, reified A2, reified A3, reified A4, reified A5, reifi
  * @param creator The function that will be called the first time an instance is requested with a new argument. Guaranteed to be called only once per argument. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2,                                     reified T: Any> Kodein.BindBuilder.WithScope<C>.multiton(ref: RefMaker? = null, sync: Boolean = true, noinline creator: SimpleBindingKodein<C>.(A1, A2            ) -> T) = Multiton(scope, contextType, Multi2.erased<A1, A2            >(), erased(), ref, sync) { creator(it.a1, it.a2                     ) }
 
 /**
@@ -100,6 +125,11 @@ inline fun <C, reified A1, reified A2,                                     reifi
  * @param creator The function that will be called the first time an instance is requested with a new argument. Guaranteed to be called only once per argument. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2, reified A3,                         reified T: Any> Kodein.BindBuilder.WithScope<C>.multiton(ref: RefMaker? = null, sync: Boolean = true, noinline creator: SimpleBindingKodein<C>.(A1, A2, A3        ) -> T) = Multiton(scope, contextType, Multi3.erased<A1, A2, A3        >(), erased(), ref, sync) { creator(it.a1, it.a2, it.a3              ) }
 
 /**
@@ -117,6 +147,11 @@ inline fun <C, reified A1, reified A2, reified A3,                         reifi
  * @param creator The function that will be called the first time an instance is requested with a new argument. Guaranteed to be called only once per argument. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2, reified A3, reified A4,             reified T: Any> Kodein.BindBuilder.WithScope<C>.multiton(ref: RefMaker? = null, sync: Boolean = true, noinline creator: SimpleBindingKodein<C>.(A1, A2, A3, A4    ) -> T) = Multiton(scope, contextType, Multi4.erased<A1, A2, A3, A4    >(), erased(), ref, sync) { creator(it.a1, it.a2, it.a3, it.a4       ) }
 
 /**
@@ -135,6 +170,11 @@ inline fun <C, reified A1, reified A2, reified A3, reified A4,             reifi
  * @param creator The function that will be called the first time an instance is requested with a new argument. Guaranteed to be called only once per argument. Should create a new instance.
  * @return A factory ready to be bound.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <C, reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> Kodein.BindBuilder.WithScope<C>.multiton(ref: RefMaker? = null, sync: Boolean = true, noinline creator: SimpleBindingKodein<C>.(A1, A2, A3, A4, A5) -> T) = Multiton(scope, contextType, Multi5.erased<A1, A2, A3, A4, A5>(), erased(), ref, sync) { creator(it.a1, it.a2, it.a3, it.a4, it.a5) }
 
 
@@ -150,6 +190,11 @@ inline fun <C, reified A1, reified A2, reified A3, reified A4, reified A5, reifi
  * @param a2 The second argument.
  */
 @Suppress("FunctionName")
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2                                    > M(a1: A1, a2: A2                        ) = Multi2(a1, a2,             Multi2.erased())
 
 /**
@@ -165,6 +210,11 @@ inline fun <reified A1, reified A2                                    > M(a1: A1
  * @param a3 The third argument.
  */
 @Suppress("FunctionName")
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3                        > M(a1: A1, a2: A2, a3: A3                ) = Multi3(a1, a2, a3,         Multi3.erased())
 
 /**
@@ -182,6 +232,11 @@ inline fun <reified A1, reified A2, reified A3                        > M(a1: A1
  * @param a4 The fourth argument.
  */
 @Suppress("FunctionName")
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4            > M(a1: A1, a2: A2, a3: A3, a4: A4        ) = Multi4(a1, a2, a3, a4,     Multi4.erased())
 
 /**
@@ -201,6 +256,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4            > M(a1: A1
  * @param a5 The fifth argument.
  */
 @Suppress("FunctionName")
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5> M(a1: A1, a2: A2, a3: A3, a4: A4, a5: A5) = Multi5(a1, a2, a3, a4, a5, Multi5.erased())
 
 
@@ -209,6 +269,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5> M(a1: A1
  *
  * The generic parameters themselves will be erased!
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2                                    > Multi2.Companion.erased() = erasedComp2<Multi2<A1, A2            >, A1, A2            >()
 
 /**
@@ -216,6 +281,11 @@ inline fun <reified A1, reified A2                                    > Multi2.C
  *
  * The generic parameters themselves will be erased!
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3                        > Multi3.Companion.erased() = erasedComp3<Multi3<A1, A2, A3        >, A1, A2, A3        >()
 
 /**
@@ -223,6 +293,11 @@ inline fun <reified A1, reified A2, reified A3                        > Multi3.C
  *
  * The generic parameters themselves will be erased!
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4            > Multi4.Companion.erased() = erasedComp4<Multi4<A1, A2, A3, A4    >, A1, A2, A3, A4    >()
 
 /**
@@ -230,6 +305,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4            > Multi4.C
  *
  * The generic parameters themselves will be erased!
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5> Multi5.Companion.erased() = erasedComp5<Multi5<A1, A2, A3, A4, A5>, A1, A2, A3, A4, A5>()
 
 

--- a/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_20_1_MultiArguments_deprecated.kt
+++ b/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_20_1_MultiArguments_deprecated.kt
@@ -1,0 +1,159 @@
+package org.kodein.di.erased
+
+import org.kodein.di.*
+import org.kodein.di.test.*
+import kotlin.test.*
+
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+class ErasedTests_20_1_MultiArguments_deprecated {
+
+    @Test
+    fun test_00_MultiArgumentsFactory() {
+        val kodein = Kodein {
+            bind<FullName>() with factory { firstName: String, lastName: String -> FullName(firstName, lastName) }
+        }
+
+        val i: FullName by kodein.instance(arg = M("Salomon", "BRYS"))
+        val ni: FullName? by kodein.instanceOrNull(arg = M("Salomon", 42))
+        val nni: FullName? by kodein.instanceOrNull(arg = M("Salomon", "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = M("Salomon", "BRYS"))
+        val dni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", 42))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = M("Salomon", "BRYS"))
+        val np: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", 42))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = M("Salomon", "BRYS"))
+        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", 42))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", "BRYS"))
+
+        assertAllNull(ni, dni, np, dnp)
+        assertAllNotNull(nni, dnni, nnp, dnnp)
+
+        assertAllEqual(FullName("Salomon", "BRYS"), i, nni!!, di, dnni, p(), nnp!!(), dp(), dnnp!!())
+    }
+
+    @Test
+    fun test_01_MultiArgumentsMultiton() {
+        val kodein = Kodein {
+            bind<FullName>() with multiton { firstName: String, lastName: String -> FullName(firstName, lastName) }
+        }
+
+        val i: FullName by kodein.instance(arg = M("Salomon", "BRYS"))
+        val ni: FullName? by kodein.instanceOrNull(arg = M("Salomon", 42))
+        val nni: FullName? by kodein.instanceOrNull(arg = M("Salomon", "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = M("Salomon", "BRYS"))
+        val dni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", 42))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = M("Salomon", "BRYS"))
+        val np: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", 42))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = M("Salomon", "BRYS"))
+        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", 42))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", "BRYS"))
+
+        assertAllNull(ni, dni, np, dnp)
+        assertAllNotNull(nni, dnni, nnp, dnnp)
+
+        assertAllEqual(FullName("Salomon", "BRYS"), i, nni!!, di, dnni, p(), nnp!!(), dp(), dnnp!!())
+    }
+
+    @Test
+    fun test_02_MultiArgumentsFactoryBadType() {
+        val kodein = Kodein {
+            bind<FullName>() with factory { firstName: String, lastName: String -> FullName(firstName, lastName) }
+        }
+
+        assertFailsWith<Kodein.NotFoundException> {
+            @Suppress("UNUSED_VARIABLE")
+            val fullName: FullName = kodein.direct.instance(arg = M("Salomon", 42))
+        }
+    }
+
+    @Test
+    fun test_03_BigMultiArgumentsFactories() {
+        val kodein = Kodein {
+            bind<String>() with factory { a: String -> "Mr $a" }
+            bind<String>() with factory { a: String, b: String -> "Mr $a $b" }
+            bind<String>() with factory { a: String, b: String, c: String -> "Mr $a $b of $c" }
+            bind<String>() with factory { a: String, b: String, c: String, d: String -> "Mr $a $b of $c, $d" }
+            bind<String>() with factory { a: String, b: String, c: String, d: String, e: String -> "Mr $a $b of $c, $d in $e" }
+        }
+
+        assertEquals("Mr Salomon", kodein.direct.instance(arg = "Salomon"))
+        assertEquals("Mr Salomon BRYS", kodein.direct.instance(arg = M("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", kodein.direct.instance(arg = M("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", kodein.direct.instance(arg = M("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", kodein.direct.instance(arg = M("Salomon", "BRYS", "Paris", "France", "Europe")))
+    }
+
+    @Test
+    fun test_04_MultiArgumentsFactoryFunction() {
+        val kodein = Kodein {
+            bind<String>() with factory { a: String -> "Mr $a" }
+            bind<String>() with factory { a: String, b: String -> "Mr $a $b" }
+            bind<String>() with factory { a: String, b: String, c: String -> "Mr $a $b of $c" }
+            bind<String>() with factory { a: String, b: String, c: String, d: String -> "Mr $a $b of $c, $d" }
+            bind<String>() with factory { a: String, b: String, c: String, d: String, e: String -> "Mr $a $b of $c, $d in $e" }
+        }
+
+        val f1: (String) -> String by kodein.factory()
+        val f2: (String, String) -> String by kodein.factory2()
+        val f3: (String, String, String) -> String by kodein.factory3()
+        val f4: (String, String, String, String) -> String by kodein.factory4()
+        val f5: (String, String, String, String, String) -> String by kodein.factory5()
+        val fn1: ((Int) -> String)? by kodein.factoryOrNull()
+        val fn2: ((Int, Int) -> String)? by kodein.factory2OrNull()
+        val fn3: ((Int, Int, Int) -> String)? by kodein.factory3OrNull()
+        val fn4: ((Int, Int, Int, Int) -> String)? by kodein.factory4OrNull()
+        val fn5: ((Int, Int, Int, Int, Int) -> String)? by kodein.factory5OrNull()
+
+        assertEquals("Mr Salomon", f1("Salomon"))
+        assertEquals("Mr Salomon BRYS", f2("Salomon", "BRYS"))
+        assertEquals("Mr Salomon BRYS of Paris", f3("Salomon", "BRYS", "Paris"))
+        assertEquals("Mr Salomon BRYS of Paris, France", f4("Salomon", "BRYS", "Paris", "France"))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", f5("Salomon", "BRYS", "Paris", "France", "Europe"))
+        assertNull(fn1)
+        assertNull(fn2)
+        assertNull(fn3)
+        assertNull(fn4)
+        assertNull(fn5)
+    }
+
+    @Test
+    fun test_05_MultiArgumentsFactoryDirectFunction() {
+        val kodein = Kodein.direct {
+            bind<String>() with factory { a: String -> "Mr $a" }
+            bind<String>() with factory { a: String, b: String -> "Mr $a $b" }
+            bind<String>() with factory { a: String, b: String, c: String -> "Mr $a $b of $c" }
+            bind<String>() with factory { a: String, b: String, c: String, d: String -> "Mr $a $b of $c, $d" }
+            bind<String>() with factory { a: String, b: String, c: String, d: String, e: String -> "Mr $a $b of $c, $d in $e" }
+        }
+
+        val f1: (String) -> String = kodein.factory()
+        val f2: (String, String) -> String = kodein.factory2()
+        val f3: (String, String, String) -> String = kodein.factory3()
+        val f4: (String, String, String, String) -> String = kodein.factory4()
+        val f5: (String, String, String, String, String) -> String = kodein.factory5()
+        val fn1: ((Int) -> String)? = kodein.factoryOrNull()
+        val fn2: ((Int, Int) -> String)? = kodein.factory2OrNull()
+        val fn3: ((Int, Int, Int) -> String)? = kodein.factory3OrNull()
+        val fn4: ((Int, Int, Int, Int) -> String)? = kodein.factory4OrNull()
+        val fn5: ((Int, Int, Int, Int, Int) -> String)? = kodein.factory5OrNull()
+
+        assertEquals("Mr Salomon", f1("Salomon"))
+        assertEquals("Mr Salomon BRYS", f2("Salomon", "BRYS"))
+        assertEquals("Mr Salomon BRYS of Paris", f3("Salomon", "BRYS", "Paris"))
+        assertEquals("Mr Salomon BRYS of Paris, France", f4("Salomon", "BRYS", "Paris", "France"))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", f5("Salomon", "BRYS", "Paris", "France", "Europe"))
+        assertNull(fn1)
+        assertNull(fn2)
+        assertNull(fn3)
+        assertNull(fn4)
+        assertNull(fn5)
+    }
+}

--- a/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_20_2_MultiArguments.kt
+++ b/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_20_2_MultiArguments.kt
@@ -5,7 +5,7 @@ import org.kodein.di.test.*
 import kotlin.test.*
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-class ErasedTests_20_MultiArguments {
+class ErasedTests_20_2_MultiArguments {
 
     private data class Person(val firstName: String, val lastName: String)
     private data class MultiArgElement(val a1: String = "", val a2: String = "", val a3: String = "", val a4: String = "", val a5: String = "") {
@@ -25,15 +25,20 @@ class ErasedTests_20_MultiArguments {
             bind<FullName>() with factory { p: Person -> FullName(p.firstName, p.lastName) }
         }
 
-        val i: FullName by kodein.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val nni: FullName? by kodein.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val di: FullName = kodein.direct.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val dnni: FullName? = kodein.direct.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val p: () -> FullName by kodein.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val dp: () -> FullName = kodein.direct.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
-        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val i: FullName by kodein.instance(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val ni: FullName? by kodein.instanceOrNull(arg = Person(name = "Salomon"))
+        val nni: FullName? by kodein.instanceOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val dni: FullName? = kodein.direct.instanceOrNull(arg = Person(name = "Salomon"))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val np: (() -> FullName)? by kodein.providerOrNull(arg = Person(name = "Salomon"))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(name = "Salomon"))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
 
+        assertAllNull(ni, dni, np, dnp)
         assertAllNotNull(nni, dnni, nnp, dnnp)
 
         assertAllEqual(FullName("Salomon", "BRYS"), i, nni!!, di, dnni, p(), nnp!!(), dp(), dnnp!!())
@@ -42,21 +47,21 @@ class ErasedTests_20_MultiArguments {
     @Test
     fun test_01_MultiArgumentsMultiton() {
         val kodein = Kodein {
-            bind<FullName>() with multiton { firstName: String, lastName: String -> FullName(firstName, lastName) }
+            bind<FullName>() with multiton { p: Person -> FullName(p.firstName, p.lastName) }
         }
 
-        val i: FullName by kodein.instance(arg = M("Salomon", "BRYS"))
-        val ni: FullName? by kodein.instanceOrNull(arg = M("Salomon", 42))
-        val nni: FullName? by kodein.instanceOrNull(arg = M("Salomon", "BRYS"))
-        val di: FullName = kodein.direct.instance(arg = M("Salomon", "BRYS"))
-        val dni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", 42))
-        val dnni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", "BRYS"))
-        val p: () -> FullName by kodein.provider(arg = M("Salomon", "BRYS"))
-        val np: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", 42))
-        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", "BRYS"))
-        val dp: () -> FullName = kodein.direct.provider(arg = M("Salomon", "BRYS"))
-        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", 42))
-        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", "BRYS"))
+        val i: FullName by kodein.instance(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val ni: FullName? by kodein.instanceOrNull(arg = Person(name = "Salomon"))
+        val nni: FullName? by kodein.instanceOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val dni: FullName? = kodein.direct.instanceOrNull(arg = Person(name = "Salomon"))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val np: (() -> FullName)? by kodein.providerOrNull(arg = Person(name = "Salomon"))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
+        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(name = "Salomon"))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(firstName = "Salomon",lastName =  "BRYS"))
 
         assertAllNull(ni, dni, np, dnp)
         assertAllNotNull(nni, dnni, nnp, dnnp)
@@ -67,12 +72,12 @@ class ErasedTests_20_MultiArguments {
     @Test
     fun test_02_MultiArgumentsFactoryBadType() {
         val kodein = Kodein {
-            bind<FullName>() with factory { firstName: String, lastName: String -> FullName(firstName, lastName) }
+            bind<FullName>() with factory { p: Person -> FullName(p.firstName, p.lastName) }
         }
 
         assertFailsWith<Kodein.NotFoundException> {
             @Suppress("UNUSED_VARIABLE")
-            val fullName: FullName = kodein.direct.instance(arg = M("Salomon", 42))
+            val fullName: FullName = kodein.direct.instance(arg = org.kodein.di.test.Person("Salomon"))
         }
     }
 

--- a/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_20_MultiArguments.kt
+++ b/kodein-di-erased/src/commonTest/kotlin/org/kodein/di/erased/ErasedTests_20_MultiArguments.kt
@@ -1,36 +1,39 @@
 package org.kodein.di.erased
 
-import org.kodein.di.Kodein
-import org.kodein.di.direct
+import org.kodein.di.*
 import org.kodein.di.test.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertNull
+import kotlin.test.*
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class ErasedTests_20_MultiArguments {
 
+    private data class Person(val firstName: String, val lastName: String)
+    private data class MultiArgElement(val a1: String = "", val a2: String = "", val a3: String = "", val a4: String = "", val a5: String = "") {
+        override fun toString(): String {
+            fun concat(prefix: String = "", value: String): String = if (value.isNotEmpty()) "$prefix $value" else ""
+            return "Mr $a1" +
+                    concat(value = a2) +
+                    concat(" of", a3) +
+                    concat(",", a4) +
+                    concat(" in", a5)
+        }
+    }
+
     @Test
     fun test_00_MultiArgumentsFactory() {
         val kodein = Kodein {
-            bind<FullName>() with factory { firstName: String, lastName: String -> FullName(firstName, lastName) }
+            bind<FullName>() with factory { p: Person -> FullName(p.firstName, p.lastName) }
         }
 
-        val i: FullName by kodein.instance(arg = M("Salomon", "BRYS"))
-        val ni: FullName? by kodein.instanceOrNull(arg = M("Salomon", 42))
-        val nni: FullName? by kodein.instanceOrNull(arg = M("Salomon", "BRYS"))
-        val di: FullName = kodein.direct.instance(arg = M("Salomon", "BRYS"))
-        val dni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", 42))
-        val dnni: FullName? = kodein.direct.instanceOrNull(arg = M("Salomon", "BRYS"))
-        val p: () -> FullName by kodein.provider(arg = M("Salomon", "BRYS"))
-        val np: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", 42))
-        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = M("Salomon", "BRYS"))
-        val dp: () -> FullName = kodein.direct.provider(arg = M("Salomon", "BRYS"))
-        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", 42))
-        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = M("Salomon", "BRYS"))
+        val i: FullName by kodein.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val nni: FullName? by kodein.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
 
-        assertAllNull(ni, dni, np, dnp)
         assertAllNotNull(nni, dnni, nnp, dnnp)
 
         assertAllEqual(FullName("Salomon", "BRYS"), i, nni!!, di, dnni, p(), nnp!!(), dp(), dnnp!!())
@@ -76,84 +79,48 @@ class ErasedTests_20_MultiArguments {
     @Test
     fun test_03_BigMultiArgumentsFactories() {
         val kodein = Kodein {
-            bind<String>() with factory { a: String -> "Mr $a" }
-            bind<String>() with factory { a: String, b: String -> "Mr $a $b" }
-            bind<String>() with factory { a: String, b: String, c: String -> "Mr $a $b of $c" }
-            bind<String>() with factory { a: String, b: String, c: String, d: String -> "Mr $a $b of $c, $d" }
-            bind<String>() with factory { a: String, b: String, c: String, d: String, e: String -> "Mr $a $b of $c, $d in $e" }
+            bind<String>() with factory { m: MultiArgElement -> m.toString() }
         }
 
-        assertEquals("Mr Salomon", kodein.direct.instance(arg = "Salomon"))
-        assertEquals("Mr Salomon BRYS", kodein.direct.instance(arg = M("Salomon", "BRYS")))
-        assertEquals("Mr Salomon BRYS of Paris", kodein.direct.instance(arg = M("Salomon", "BRYS", "Paris")))
-        assertEquals("Mr Salomon BRYS of Paris, France", kodein.direct.instance(arg = M("Salomon", "BRYS", "Paris", "France")))
-        assertEquals("Mr Salomon BRYS of Paris, France in Europe", kodein.direct.instance(arg = M("Salomon", "BRYS", "Paris", "France", "Europe")))
+        assertEquals("Mr Salomon", kodein.direct.instance(arg = MultiArgElement("Salomon")))
+        assertEquals("Mr Salomon BRYS", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
     }
 
     @Test
     fun test_04_MultiArgumentsFactoryFunction() {
         val kodein = Kodein {
-            bind<String>() with factory { a: String -> "Mr $a" }
-            bind<String>() with factory { a: String, b: String -> "Mr $a $b" }
-            bind<String>() with factory { a: String, b: String, c: String -> "Mr $a $b of $c" }
-            bind<String>() with factory { a: String, b: String, c: String, d: String -> "Mr $a $b of $c, $d" }
-            bind<String>() with factory { a: String, b: String, c: String, d: String, e: String -> "Mr $a $b of $c, $d in $e" }
+            bind<String>() with factory { m: MultiArgElement -> m.toString() }
         }
 
-        val f1: (String) -> String by kodein.factory()
-        val f2: (String, String) -> String by kodein.factory2()
-        val f3: (String, String, String) -> String by kodein.factory3()
-        val f4: (String, String, String, String) -> String by kodein.factory4()
-        val f5: (String, String, String, String, String) -> String by kodein.factory5()
-        val fn1: ((Int) -> String)? by kodein.factoryOrNull()
-        val fn2: ((Int, Int) -> String)? by kodein.factory2OrNull()
-        val fn3: ((Int, Int, Int) -> String)? by kodein.factory3OrNull()
-        val fn4: ((Int, Int, Int, Int) -> String)? by kodein.factory4OrNull()
-        val fn5: ((Int, Int, Int, Int, Int) -> String)? by kodein.factory5OrNull()
+        val factory: (MultiArgElement) -> String by kodein.factory()
+        val factoryNull: ((Int) -> String)? by kodein.factoryOrNull()
 
-        assertEquals("Mr Salomon", f1("Salomon"))
-        assertEquals("Mr Salomon BRYS", f2("Salomon", "BRYS"))
-        assertEquals("Mr Salomon BRYS of Paris", f3("Salomon", "BRYS", "Paris"))
-        assertEquals("Mr Salomon BRYS of Paris, France", f4("Salomon", "BRYS", "Paris", "France"))
-        assertEquals("Mr Salomon BRYS of Paris, France in Europe", f5("Salomon", "BRYS", "Paris", "France", "Europe"))
-        assertNull(fn1)
-        assertNull(fn2)
-        assertNull(fn3)
-        assertNull(fn4)
-        assertNull(fn5)
+        assertEquals("Mr Salomon", factory(MultiArgElement("Salomon")))
+        assertEquals("Mr Salomon BRYS", factory(MultiArgElement("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", factory(MultiArgElement("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
+        assertNull(factoryNull)
     }
 
     @Test
     fun test_05_MultiArgumentsFactoryDirectFunction() {
         val kodein = Kodein.direct {
-            bind<String>() with factory { a: String -> "Mr $a" }
-            bind<String>() with factory { a: String, b: String -> "Mr $a $b" }
-            bind<String>() with factory { a: String, b: String, c: String -> "Mr $a $b of $c" }
-            bind<String>() with factory { a: String, b: String, c: String, d: String -> "Mr $a $b of $c, $d" }
-            bind<String>() with factory { a: String, b: String, c: String, d: String, e: String -> "Mr $a $b of $c, $d in $e" }
+            bind<String>() with factory { m: MultiArgElement -> m.toString() }
         }
 
-        val f1: (String) -> String = kodein.factory()
-        val f2: (String, String) -> String = kodein.factory2()
-        val f3: (String, String, String) -> String = kodein.factory3()
-        val f4: (String, String, String, String) -> String = kodein.factory4()
-        val f5: (String, String, String, String, String) -> String = kodein.factory5()
-        val fn1: ((Int) -> String)? = kodein.factoryOrNull()
-        val fn2: ((Int, Int) -> String)? = kodein.factory2OrNull()
-        val fn3: ((Int, Int, Int) -> String)? = kodein.factory3OrNull()
-        val fn4: ((Int, Int, Int, Int) -> String)? = kodein.factory4OrNull()
-        val fn5: ((Int, Int, Int, Int, Int) -> String)? = kodein.factory5OrNull()
+        val factory: (MultiArgElement) -> String = kodein.factory()
+        val factoryNull: ((Int) -> String)? = kodein.factoryOrNull()
 
-        assertEquals("Mr Salomon", f1("Salomon"))
-        assertEquals("Mr Salomon BRYS", f2("Salomon", "BRYS"))
-        assertEquals("Mr Salomon BRYS of Paris", f3("Salomon", "BRYS", "Paris"))
-        assertEquals("Mr Salomon BRYS of Paris, France", f4("Salomon", "BRYS", "Paris", "France"))
-        assertEquals("Mr Salomon BRYS of Paris, France in Europe", f5("Salomon", "BRYS", "Paris", "France", "Europe"))
-        assertNull(fn1)
-        assertNull(fn2)
-        assertNull(fn3)
-        assertNull(fn4)
-        assertNull(fn5)
+        assertEquals("Mr Salomon", factory(MultiArgElement("Salomon")))
+        assertEquals("Mr Salomon BRYS", factory(MultiArgElement("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", factory(MultiArgElement("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
+        assertNull(factoryNull)
     }
     
 }

--- a/kodein-di-generic-jvm/src/main/kotlin/org/kodein/di/generic/GMulti.kt
+++ b/kodein-di-generic-jvm/src/main/kotlin/org/kodein/di/generic/GMulti.kt
@@ -217,6 +217,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5> M(a1: A1
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> KodeinAware.factory2(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi2<A1, A2            >, T>(generic(), generic(), tag)) { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } }
 
@@ -234,6 +239,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> KodeinAware.factory3(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi3<A1, A2, A3        >, T>(generic(), generic(), tag)) { { a1: A1, a2: A2, a3: A3                 -> it(M(a1, a2, a3        )) } }
 
@@ -252,6 +262,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> KodeinAware.factory4(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi4<A1, A2, A3, A4    >, T>(generic(), generic(), tag)) { { a1: A1, a2: A2, a3: A3, a4: A4         -> it(M(a1, a2, a3, a4    )) } }
 
@@ -271,6 +286,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> KodeinAware.factory5(tag: Any? = null) =
         KodeinPropertyMap(Factory<Multi5<A1, A2, A3, A4, A5>, T>(generic(), generic(), tag)) { { a1: A1, a2: A2, a3: A3, a4: A4, a5: A5 -> it(M(a1, a2, a3, a4, a5)) } }
 
@@ -288,6 +308,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> KodeinAware.factory2OrNull(tag: Any? = null) =
         KodeinPropertyMap(FactoryOrNull<Multi2<A1, A2            >, T>(generic(), generic(), tag)) { factory -> factory?.let { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } } }
 
@@ -305,6 +330,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> KodeinAware.factory3OrNull(tag: Any? = null) =
         KodeinPropertyMap(FactoryOrNull<Multi3<A1, A2, A3        >, T>(generic(), generic(), tag)) { factory -> factory?.let { { a1: A1, a2: A2, a3: A3                 -> it(M(a1, a2, a3        )) } } }
 
@@ -323,6 +353,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> KodeinAware.factory4OrNull(tag: Any? = null) =
         KodeinPropertyMap(FactoryOrNull<Multi4<A1, A2, A3, A4    >, T>(generic(), generic(), tag)) { factory -> factory?.let { { a1: A1, a2: A2, a3: A3, a4: A4         -> it(M(a1, a2, a3, a4    )) } } }
 
@@ -342,6 +377,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> KodeinAware.factory5OrNull(tag: Any? = null) =
         KodeinPropertyMap(FactoryOrNull<Multi5<A1, A2, A3, A4, A5>, T>(generic(), generic(), tag)) { factory -> factory?.let { { a1: A1, a2: A2, a3: A3, a4: A4, a5: A5 -> it(M(a1, a2, a3, a4, a5)) } } }
 
@@ -359,6 +399,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> DKodein.factory2(tag: Any? = null) =
     Factory<Multi2<A1, A2            >, T>(generic(), generic(), tag).let { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } }
 
@@ -376,6 +421,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> DKodein.factory3(tag: Any? = null) =
     Factory<Multi3<A1, A2, A3        >, T>(generic(), generic(), tag).let { { a1: A1, a2: A2, a3: A3                 -> it(M(a1, a2, a3        )) } }
 
@@ -394,6 +444,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> DKodein.factory4(tag: Any? = null) =
     Factory<Multi4<A1, A2, A3, A4    >, T>(generic(), generic(), tag).let { { a1: A1, a2: A2, a3: A3, a4: A4         -> it(M(a1, a2, a3, a4    )) } }
 
@@ -413,6 +468,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> DKodein.factory5(tag: Any? = null) =
     Factory<Multi5<A1, A2, A3, A4, A5>, T>(generic(), generic(), tag).let { { a1: A1, a2: A2, a3: A3, a4: A4, a5: A5 -> it(M(a1, a2, a3, a4, a5)) } }
 
@@ -430,6 +490,11 @@ inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2,                                     reified T: Any> DKodein.factory2OrNull(tag: Any? = null) =
         FactoryOrNull<Multi2<A1, A2            >, T>(generic(), generic(), tag).let { factory -> factory?.let { { a1: A1, a2: A2                         -> it(M(a1, a2            )) } } }
 
@@ -447,6 +512,11 @@ inline fun <reified A1, reified A2,                                     reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3,                         reified T: Any> DKodein.factory3OrNull(tag: Any? = null) =
         FactoryOrNull<Multi3<A1, A2, A3        >, T>(generic(), generic(), tag).let { factory -> factory?.let { { a1: A1, a2: A2, a3: A3                 -> it(M(a1, a2, a3        )) } } }
 
@@ -465,6 +535,11 @@ inline fun <reified A1, reified A2, reified A3,                         reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4,             reified T: Any> DKodein.factory4OrNull(tag: Any? = null) =
         FactoryOrNull<Multi4<A1, A2, A3, A4    >, T>(generic(), generic(), tag).let { factory -> factory?.let { { a1: A1, a2: A2, a3: A3, a4: A4         -> it(M(a1, a2, a3, a4    )) } } }
 
@@ -484,5 +559,10 @@ inline fun <reified A1, reified A2, reified A3, reified A4,             reified 
  * @throws Kodein.NotFoundException if no factory was found.
  * @throws Kodein.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
+// Deprecated Since 6.4
+@Deprecated(message="Multi argument factories are confusing for lot of users, " +
+        "we recommend using a data class to pass multiple values to a factory. " +
+        "\n(see https://github.com/Kodein-Framework/Kodein-DI/issues/240)" +
+        "\ntThis will be removed in 7.0", level = DeprecationLevel.WARNING)
 inline fun <reified A1, reified A2, reified A3, reified A4, reified A5, reified T: Any> DKodein.factory5OrNull(tag: Any? = null) =
         FactoryOrNull<Multi5<A1, A2, A3, A4, A5>, T>(generic(), generic(), tag).let { factory -> factory?.let { { a1: A1, a2: A2, a3: A3, a4: A4, a5: A5 -> it(M(a1, a2, a3, a4, a5)) } } }


### PR DESCRIPTION
What have been done:
- Depreciate factories retrieval functions
    - `factory2()` / `factory3()` / `factory4()` / `factory5()`
- Depreciate factories and multiton functions with multi-arg only
    - `factory(MultiX)` / `multiton(MultiX)`
- Depreciate `MultiX` tuples as they are used only for multi-arg factories
- Depreciate multi-arg tests
- Create new tests with data class usage instead of multi-arg
- Adapt documentation (should be revamped after removal as we reference multi-arg as deprecated)