### PR TITLE
[DOC] Fix typos

### DIFF
--- a/doc/core.adoc
+++ b/doc/core.adoc
@@ -1883,7 +1883,7 @@ val configurations by kodein.instance<ConfigurationEntries>().toMap()
 ----
 
 
- [[debugging]]
+[[debugging]]
 == Debugging
 
 === Print bindings
@@ -1902,8 +1902,8 @@ Here's an example of what this prints:
 
 As you can see, it's really easy to understand which type with which tag is bound to which implementation inside which scope.
 
-NOTE: Descriptions prints type names in a "kotlin-esque" way.
-      Because Kodein does not depends on `kotlin-reflect`, it uses java `Type` objects that do not contains nullability information.
+NOTE: Description prints type names in a "kotlin-esque" way.
+      Because Kodein does not depend on `kotlin-reflect`, it uses java `Type` objects that do not contain nullability information.
       As such, the type display does not include nullability. Still, it's easier to read `List<*>` than `List<? extends Object>`.
 
 
@@ -1997,7 +1997,7 @@ Note that if no argument is provided, the argument to the lambda will be `Unit`.
 
 === The type erasure problem
 
-When using the `generic` JVM version on the, Kodein is immune to type erasure, meaning that `bind<List<String>>()` and `bind<List<Int>>()` will represent two different bindings. +
+When using the `generic` version on the JVM, Kodein is immune to type erasure, meaning that `bind<List<String>>()` and `bind<List<Int>>()` will represent two different bindings. +
 Similarly, `kodein.instance<List<String>>()` and `kodein.instance<List<Int>>()` will yield two different list.
 
 To be erasure immune, the `generic` JVM version relies heavily on the `generic` function, which is known to be slow.

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -141,8 +141,8 @@ In DI, you *bind* a type (often an interface) to a *binding* that manages an *im
 A binding is responsible for returning the implementation when asked.
 In this example, we have seen to different bindings:
 
-* The *provider* always return a new implementation instance.
-* The *singleton* creates only on implementation instance, and always return that same instance.
+* The *provider* always returns a new implementation instance.
+* The *singleton* creates only one implementation instance, and always returns that same instance.
 
 
 === Declaration


### PR DESCRIPTION
Just a few typos and one adoc error I found when reading the documentation.