### PR TITLE
change doc link from 7.2.0 to 7.1.0 as 7.2.0 appears to be unreleased.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Read more
 
 **_Kodein-DI_** 7+ is the current major version, but documentation is available for previous versions.
 
-**[Kodein-DI documentation](https://docs.kodein.org/kodein-di/7.2.0/index.html)**
+**[Kodein-DI documentation](https://docs.kodein.org/kodein-di/7.1.0/index.html)**
 
 
 Support


### PR DESCRIPTION
The doc link on the README appears to link to a version of the docs that suggests installing an unreleased version of Kodein (7.2.0) which does not appear to be on jcenter. 

```
Could not find org.kodein.di:kodein-di:7.2.0.
Required by:
    project :
```
