### PR TITLE
Small error in Android documentation

### DIFF
--- a/doc/modules/framework/pages/android.adoc
+++ b/doc/modules/framework/pages/android.adoc
@@ -139,7 +139,7 @@ NOTE: If you prefer your View Models to be independant from Kodein-DI, you can u
 [source, kotlin]
 .Example: using an trigger in a DIAware Android Activity
 ----
-class MyViewModel(app: Application) : ApplicationViewModel(app), DIAware {
+class MyViewModel(app: Application) : AndroidViewModel(app), DIAware {
 
     override val di by di() // <1>
 


### PR DESCRIPTION
The documentation itself says:

> For that, View Models need to implement `AndroidViewModel`.

But then in the code example proceeds to implement `ApplicationViewModel`.

`class MyViewModel(app: Application) : ApplicationViewModel(app), DIAware`

As a side note: 
Does the `override val di by di()` inside the viewModel perhaps need to be replaced with  `override val di by di(app)`?

Or am I just missing something?