### PR TITLE
Direct and straight binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ An example is always better than a thousand words:
 
 ```kotlin
 val di = DI {
-    bind<Dice>() with provider { RandomDice(0, 5) }
-    bind<DataSource>() with singleton { SqliteDS.open("path/to/file") }
+    bindProvider<Dice> { RandomDice(0, 5) }
+    bindSingleton<DataSource> { SqliteDS.open("path/to/file") }
 }
 
 class Controller(private di: DI) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 allprojects {
     group = "org.kodein.di"
-    version = "7.4.0"
+    version = "7.5.0"
 }

--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,6 +1,7 @@
 name: kodein-di
 title: Kodein-DI
-version: '7.4.0'
+version: '7.4'
+display_version: '7.4.0'
 nav:
   - modules/ROOT/nav.adoc
   - modules/core/nav.adoc
@@ -10,5 +11,5 @@ nav:
 asciidoc:
   attributes:
     version: '7.4.0'
-    kotlin: '1.4.30'
+    kotlin: '1.4.31'
     jdk: '1.8'

--- a/doc/modules/ROOT/pages/getting-started.adoc
+++ b/doc/modules/ROOT/pages/getting-started.adoc
@@ -32,21 +32,7 @@ DI happens only once per injected object, so to measure how critical DI is, ask 
 
 === Install
 
-==== With Maven
-
-Add the JCenter repository:
-
-[source,xml,subs="attributes"]
-----
-&lt;repositories&gt;
-    &lt;repository&gt;
-      &lt;id&gt;jcenter&lt;/id&gt;
-      &lt;url&gt;https://jcenter.bintray.com&lt;/url&gt;
-    &lt;/repository&gt;
-&lt;/repositories&gt;
-----
-
-Then add the dependency:
+Add the dependency:
 
 [source,xml,subs="attributes"]
 ----
@@ -61,7 +47,7 @@ Then add the dependency:
 
 ==== With Gradle
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----

--- a/doc/modules/core/pages/advanced.adoc
+++ b/doc/modules/core/pages/advanced.adoc
@@ -11,10 +11,10 @@ Here's an example of what this prints:
 
 .An example of di.container.tree.bindings.description:
 ----
-        bind<Dice>() with factory { Int -> RandomDice }
-        bind<DataSource>() with singleton { SQLiteDataSource }
-        bind<Random>() with provider { SecureRandom }
-        bind<String>(tag = "answer") with instance ( Int )
+        bind<Dice> { factory { Int -> RandomDice } }
+        bind<DataSource> { singleton { SQLiteDataSource } }
+        bind<Random> { provider { SecureRandom } }
+        bind<String>(tag = "answer") { instance ( Int ) }
 ----
 
 As you can see, it's really easy to understand which type with which tag is bound to which implementation inside which scope.
@@ -50,7 +50,7 @@ The message of the exception explains what is the binding the container is looki
 
 .An example of a not found exception:
 ----
-No binding found for bind<Person>() with ? { ? }
+No binding found for bind<Person> { ? { ? } }
 ----
 
 If you need to trace what are the different bindings available in the container you can use the option `fullContainerTreeOnError = true`, to log them all.
@@ -59,7 +59,7 @@ If you need to trace what are the different bindings available in the container 
 ----
 val di = DI.direct {
     fullContainerTreeOnError = true // <1>
-    bind<A>() with singleton { A(instance()) } // <2>
+    bind<A> { singleton { A(instance()) } } // <2>
 }
 di.instance<B>() // <3>
 ----
@@ -69,9 +69,9 @@ di.instance<B>() // <3>
 
 .And the trace associated to the code above:
 ----
-No binding found for bind<B>() with ? { ? }
+No binding found for bind<B> { ? { ? } }
 Registered in this DI container:
-        bind<A>() with singleton { A }
+        bind<A> { singleton { A } }
 ----
 
 

--- a/doc/modules/core/pages/bindings.adoc
+++ b/doc/modules/core/pages/bindings.adoc
@@ -299,8 +299,8 @@ val di = DI {
     bindProvider { RandomDice(20) }
     bindSingleton { RandomDice(6) }
     bindMultiton { name: String ->  Person(name) }
-    bindInstance { SqliteDataSource.open("path/to/file") }
     bindConstant("answer") { 42 }
+    bindInstance(SqliteDataSource.open("path/to/file"))
 }
 ----
 ====

--- a/doc/modules/core/pages/bindings.adoc
+++ b/doc/modules/core/pages/bindings.adoc
@@ -271,22 +271,38 @@ CAUTION: You should only use constant bindings for very simple types without inh
 
 Sometimes, it may seem overkill to specify the type to `bind` if you are binding the same type as you are creating.
 
-For this use case, you can transform any `bind<TYPE>() with ...` to `bind() from ...`.
+For this use case, you can transform any `bind<TYPE>() with ...` to `bind { ... }`.
 
 [source,kotlin]
 .Example: direct bindings
 ----
 val di = DI {
-    bind() from singleton { RandomDice(6) }
-    bind("DnD20") from provider { RandomDice(20) }
-    bind() from instance(SqliteDataSource.open("path/to/file"))
+    bind { singleton { RandomDice(6) } }
+    bind("DnD20") { provider { RandomDice(20) } }
+    bind { instance(SqliteDataSource.open("path/to/file")) }
 }
 ----
 
 CAUTION: *This should be used with care* as binding a concrete class and, therefore, having concrete dependencies is an _anti-pattern_ that later prevents modularisation and mocking / testing.
 
 WARNING: When binding a generic type, the bound type will be the specialized type, +
-e.g. `bind() from singleton { listOf(1, 2, 3, 4) }` registers the binding to `List<Int>`.
+e.g. `bind { singleton { listOf(1, 2, 3, 4) } }` registers the binding to `List<Int>`.
+
+[NOTE]
+====
+If you are binding straight types, without using tags, overriding, etc., you can use the following extension functions:
+[source,kotlin]
+.Example: simple bindings
+----
+val di = DI {
+    bindFactory { size: Int -> RandomDice(size) }
+    bindProvider { RandomDice(20) }
+    bindSingleton { RandomDice(6) }
+    bindMultiton { name: String ->  Person(name) }
+    bindInstance { SqliteDataSource.open("path/to/file") }
+}
+----
+====
 
 == Subtypes bindings
 

--- a/doc/modules/core/pages/bindings.adoc
+++ b/doc/modules/core/pages/bindings.adoc
@@ -300,6 +300,7 @@ val di = DI {
     bindSingleton { RandomDice(6) }
     bindMultiton { name: String ->  Person(name) }
     bindInstance { SqliteDataSource.open("path/to/file") }
+    bindConstant("answer") { 42 }
 }
 ----
 ====

--- a/doc/modules/core/pages/bindings.adoc
+++ b/doc/modules/core/pages/bindings.adoc
@@ -11,7 +11,7 @@ val di = DI {
 
 Bindings are declared inside a DI initialization block.
 
-A binding always starts with `bind<TYPE>() with`.
+A binding always starts with `bind<TYPE> { }`.
 
 [.lead]
 There are different ways to declare bindings:
@@ -26,9 +26,9 @@ All bindings can be tagged to allow you to bind different instances of the same 
 .Example: different Dice bindings
 ----
 val di = DI {
-    bind<Dice>() with ... // <1>
-    bind<Dice>(tag = "DnD10") with ... // <2>
-    bind<Dice>(tag = "DnD20") with ... // <2>
+    bind<Dice> { ... } // <1>
+    bind<Dice>(tag = "DnD10") { ... } // <2>
+    bind<Dice>(tag = "DnD20") { ... } // <2>
 }
 ----
 <1> Default binding (with no tag)
@@ -51,9 +51,11 @@ The provided function will be called *each time* you need an instance of the bou
 .Example: creates a new 6 sided Dice entry each time you need one
 ----
 val di = DI {
-    bind<Dice>() with provider { RandomDice(6) }
+    bind<Dice> { provider { RandomDice(6) } }
 }
 ----
+
+TIP: Ending with the same result, you can also use the simple function `bindProvider<Dice> { RandomDice(6) }`.
 
 [[singleton-bindings]]
 == Singleton binding
@@ -65,10 +67,11 @@ Therefore, the provided function will be called *only once*: the first time an i
 .Example: creates a DataSource singleton that will be initialized on first access
 ----
 val di = DI {
-    bind<DataSource>() with singleton { SqliteDS.open("path/to/file") }
+    bind<DataSource> { singleton { SqliteDS.open("path/to/file") } }
 }
 ----
 
+TIP: Ending with the same result, you can also use the simple function `bindSingleton<DataSource> { SqliteDS.open("path/to/file") }`.
 
 === Non-synced singleton
 
@@ -84,14 +87,14 @@ If you need to improve startup performance, _if you know what you are doing_, yo
 .Example: creates a DataSource non synced singleton
 ----
 val di = DI {
-    bind<DataSource>() with singleton(sync = false) { SqliteDS.open("path/to/file") }
+    bind<DataSource> { singleton(sync = false) { SqliteDS.open("path/to/file") } }
 }
 ----
 
 Using `sync = false` means that:
 
 - There will be no construction synchronicity.
-- There _may_ be multiple instance constructed.
+- There _may_ be multiple instances constructed.
 - Instance will be _reused_ as much as possible.
 
 
@@ -104,7 +107,7 @@ This is the same as a regular singleton, except that the provided function will 
 ----
 val di = DI {
     // The SQLite connection will be opened as soon as the di instance is ready
-    bind<DataSource>() with eagerSingleton { SqliteDS.open("path/to/file") }
+    bind<DataSource> { eagerSingleton { SqliteDS.open("path/to/file") } }
 }
 ----
 
@@ -118,31 +121,16 @@ The provided function will be called *each time* you need an instance of the bou
 .Example: creates a new Dice each time you need one, according to an Int representing the number of sides
 ----
 val di = DI {
-    bind<Dice>() with factory { sides: Int -> RandomDice(sides) }
+    bind<Dice> { factory { sides: Int -> RandomDice(sides) } }
 }
 ----
 
+TIP: Ending with the same result, you can also use the simple function `bindFactory<Int, DataSource> { sides: Int -> RandomDice(sides) }`.
 
 [[multi-argument-factories]]
 === Multi-arguments factories
 
-CAUTION: This multi-agrument-factories mechanism is deprecated and will be removed in version `7.0`
-
-A factory can take multiple (up to 5) arguments:
-
-[source,kotlin]
-.Example: creates a new Dice each time you need one, according to an Int representing the number of sides
-----
-val di = DI {
-    bind<Dice>() with factory { startNumber: Int, sides: Int -> RandomDice(sides) }
-}
-----
-
-NOTE: We recommend to use `data classes` instead!
-
-Regarding our users feedback, we find out that multi-arguments factories was difficult to use.
-
-Thus this mechanism will be deprecate soon. So we highly recommend that you migrate your multi-args factories to simple factories by using *data classes*.
+You can create multi-args factories by using *data classes*.
 
 [source,kotlin]
 .Example: creates a new Dice each time you need one, according to multiple parameters
@@ -150,7 +138,7 @@ Thus this mechanism will be deprecate soon. So we highly recommend that you migr
 data class DiceParams(val startNumber: Int, val sides: Int)
 
 val di = DI {
-    bind<Dice>() with factory { params: DiceParams -> RandomDice(params) }
+    bind<Dice> { factory { params: DiceParams -> RandomDice(params) } }
 }
 ----
 
@@ -164,11 +152,13 @@ In other words, for a given argument, the first time a multiton is called with t
 .Example: creates one random generator for each value
 ----
 val di = DI {
-    bind<RandomGenerator>() with multiton { max: Int -> SecureRandomGenerator(max) }
+    bind<RandomGenerator> { multiton { max: Int -> SecureRandomGenerator(max) } }
 }
 ----
 
 Just like a factory, a multiton can take multiple (up to 5) arguments.
+
+TIP: Ending with the same result, you can also use the simple function `bindMultiton<Int, RandomGenerator> { max: Int -> SecureRandomGenerator(max) }`.
 
 === non-synced multiton
 
@@ -178,10 +168,11 @@ Just like a singleton, a multiton synchronization can be disabled:
 .Example: non-synced multiton
 ----
 val di = DI {
-    bind<RandomGenerator>(sync = false) with multiton { max: Int -> SecureRandomGenerator(max) }
+    bind<RandomGenerator> { multiton(sync = false)  { max: Int -> SecureRandomGenerator(max) } }
 }
 ----
 
+TIP: Ending with the same result, you can also use the simple function `bindMultiton<Int, RandomGenerator>(sync = false) { max: Int -> SecureRandomGenerator(max) }`.
 
 == Referenced singleton or multiton binding
 
@@ -205,8 +196,8 @@ Therefore, the provided function *may or may not* be called multiple times durin
 .Example: creates a Cache object that will exist only once at a given time
 ----
 val di = DI {
-    bind<Map>() with singleton(ref = softReference) { WorldMap() } // <1>
-    bind<Client>() with singleton(ref = weakReference) { id -> clientFromDB(id) } // <2>
+    bind<Map> { singleton(ref = softReference) { WorldMap() } } // <1>
+    bind<Client> { singleton(ref = weakReference) { id -> clientFromDB(id) } }// <2>
 }
 ----
 <1> Because it's bound by a soft reference, the JVM will GC it before any `OutOfMemoryException` can occur.
@@ -224,7 +215,7 @@ Therefore, the provided function will be called *once per thread* that needs the
 .Example: creates a Cache object that will exist once per thread
 ----
 val di = DI {
-    bind<Cache>() with singleton(ref = threadLocal) { LRUCache(16 * 1024) }
+    bind<Cache> { singleton(ref = threadLocal) { LRUCache(16 * 1024) } }
 }
 ----
 
@@ -241,11 +232,12 @@ This binds a type to an instance that *already exist*.
 .Example: a DataSource binding to an already existing instance.
 ----
 val di = DI {
-    bind<DataSource>() with instance(SqliteDataSource.open("path/to/file")) // <1>
+    bind<DataSource> { instance(SqliteDataSource.open("path/to/file")) } // <1>
 }
 ----
 <1> Instance is used *with parenthesis*: it is not given a function, but an instance.
 
+TIP: Ending with the same result, you can also use the simple function `bindInstance<DataSource> { SqliteDataSource.open("path/to/file") }`.
 
 [[constant-binding]]
 === Constant binding
@@ -258,8 +250,8 @@ NOTE: Constants are always <<tagged-bindings,tagged>>.
 .Example: two constants
 ----
 val di = DI {
-    constant(tag = "maxThread") with 8 // <1>
-    constant(tag = "serverURL") with "https://my.server.url" // <1>
+    bindConstant(tag = "maxThread") { 8 } // <1>
+    bindConstant(tag = "serverURL") { "https://my.server.url" } // <1>
 }
 ----
 <1> Note the absence of curly braces: it is not given a function, but an instance.
@@ -290,7 +282,7 @@ e.g. `bind { singleton { listOf(1, 2, 3, 4) } }` registers the binding to `List<
 
 [NOTE]
 ====
-If you are binding straight types, without using tags, overriding, etc., you can use the following extension functions:
+If you are binding straight types you can use the following extension functions:
 [source,kotlin]
 .Example: simple bindings
 ----
@@ -347,10 +339,10 @@ It is really easy to bind this `RandomDice` with its transitive dependencies, by
 .Example: bindings of a Dice and of its transitive dependencies
 ----
 val di = DI {
-    bind<Dice>() with singleton { Dice(instance(), instance(tag = "max")) } // <1>
+    bind<Dice> { singleton { Dice(instance(), instance(tag = "max")) } } // <1>
 
-    bind<Random>() with provider { SecureRandom() } // <2>
-    constant(tag="max") with 5 // <2>
+    bind<Random> {provider { SecureRandom() } } // <2>
+    bindConstant(tag="max"){ 5 } // <2>
 }
 ----
 <1> Binding of `Dice`. It gets its transitive dependencies by using `instance()` and `instance(tag)`.
@@ -370,8 +362,8 @@ Maybe you need a dependency to use one of its functions to create the bound type
 .Example: using a DataSource to create a Connection.
 ----
 val di = DI {
-    bind<DataSource>() with singleton { MySQLDataSource() }
-    bind<Connection>() with provider { instance<DataSource>().openConnection() } // <1>
+    bind<DataSource> { singleton { MySQLDataSource() } }
+    bind<Connection> { provider { instance<DataSource>().openConnection() } } // <1>
 }
 ----
 <1> Using a `DataSource` as a transitive factory dependency.
@@ -385,7 +377,7 @@ If the bound class is <<di-aware,DIAware>>, you can pass the `di` object to the 
 .Example: bindings of Manager that is responsible for retrieving its own dependencies
 ----
 val di = DI {
-    bind<Manager>() with singleton { ManagerImpl(di) } // <1>
+    bind<Manager> { singleton { ManagerImpl(di) } } // <1>
 }
 ----
 <1> ManagerImpl is given a DI instance.

--- a/doc/modules/core/pages/injection-retrieval.adoc
+++ b/doc/modules/core/pages/injection-retrieval.adoc
@@ -4,11 +4,11 @@
 .Example bindings that are used throughout the chapter:
 ----
 val di = DI {
-    bind<Dice>() with factory { sides: Int -> RandomDice(sides) }
-    bind<DataSource>() with singleton { SqliteDS.open("path/to/file") }
-    bind<Random>() with provider { SecureRandom() }
-    bind<FileAccess>() with factory { path: String, mode: Int -> FileAccess.open(path, mode) }
-    constant("answer") with "fourty-two"
+    bind<Dice> { factory { sides: Int -> RandomDice(sides) } }
+    bind<DataSource> { singleton { SqliteDS.open("path/to/file") } }
+    bind<Random> { provider { SecureRandom() } }
+    bind<FileAccess>() { factory { path: String, mode: Int -> FileAccess.open(path, mode) } }
+    bindConstant("answer") { "fourty-two" }
 }
 ----
 
@@ -360,7 +360,7 @@ Note that you can also lazily create a `DI` object so that the bindings definiti
 .Example: Using a lazy DI.
 ----
 val di by DI.lazy {
-    bind<Env>() with instance(Env.getInstance())
+    bind<Env> { instance(Env.getInstance()) }
 }
 val env: Env by di.instance()
 /*...*/

--- a/doc/modules/core/pages/install.adoc
+++ b/doc/modules/core/pages/install.adoc
@@ -6,7 +6,7 @@
 
 === With Gradle
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----
@@ -39,21 +39,7 @@ enableFeaturePreview("GRADLE_METADATA")
 Or, import the JVM binaries with `implementation("org.kodein.di:kodein-di-jvm:{version}")`.
 ====
 
-=== With Maven
-
-Add the JCenter repository:
-
-[source,xml,subs="attributes"]
-----
-&lt;repositories&gt;
-    &lt;repository&gt;
-      &lt;id&gt;jcenter&lt;/id&gt;
-      &lt;url&gt;https://jcenter.bintray.com&lt;/url&gt;
-    &lt;/repository&gt;
-&lt;/repositories&gt;
-----
-
-Then add the dependency:
+Add the dependency:
 
 [source,xml,subs="attributes"]
 ----
@@ -88,7 +74,7 @@ enableFeaturePreview("GRADLE_METADATA")
 
 ====
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----
@@ -124,7 +110,7 @@ Because _Kodein-DI_ for JavaScript is compiled as a https://github.com/umdjs/umd
 ** Directly in an HTML page with a `<script>` tag (See index2.html in the demo project).
 * In NodeJS, as a regular CJS module.
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----

--- a/doc/modules/core/pages/modules-inheritance.adoc
+++ b/doc/modules/core/pages/modules-inheritance.adoc
@@ -14,7 +14,7 @@ A module is an object that you can construct the exact same way as you construct
 .Example: a simple module
 ----
 val apiModule = DI.Module(name = "API") {
-    bind<API>() with singleton { APIImpl() }
+    bind<API> { singleton { APIImpl() } }
     /* other bindings */
 }
 ----
@@ -113,9 +113,9 @@ You can override an existing binding by specifying explicitly that it is an over
 .Example: binds twice the same type, the second time explitly specifying an override
 ----
 val di = DI {
-    bind<API>() with singleton { APIImpl() }
+    bind<API> { singleton { APIImpl() } }
     /* ... */
-    bind<API>(overrides = true) with singleton { OtherAPIImpl() }
+    bind<API>(overrides = true) { singleton { OtherAPIImpl() } }
 }
 ----
 
@@ -140,7 +140,7 @@ Those cases should be rare and you should know what you are doing.
 .Example: declaring a module in which each binding may or may not override existing bindings.
 ----
 val testModule = DI.Module(name = "test", allowSilentOverride = true) {
-    bind<EmailClient>() with singleton { MockEmailClient() } // <1>
+    bind<EmailClient>() { singleton { MockEmailClient() } } // <1>
 }
 ----
 <1> Maybe adding a new binding, maybe overriding an existing one, who knows?
@@ -152,7 +152,7 @@ This is useful if you want to "enhance" a binding (for example, using the decora
 .Example: declaring a module in which each binding may or may not override existing bindings.
 ----
 val testModule = DI.Module(name = "test") {
-    bind<Logger>(overrides = true) with singleton { FileLoggerWrapper("path/to/file", overriddenInstance()) } // <1>
+    bind<Logger>(overrides = true) { singleton { FileLoggerWrapper("path/to/file", overriddenInstance()) } } // <1>
 }
 ----
 <1> `overriddenInstance()` will return the `Logger` instance retrieved by the overridden binding.
@@ -167,13 +167,13 @@ Let's consider the following code :
 .Example: Mixing overriding & extension
 ----
 val parent = DI {
-    bind<Foo>() with provider { Foo1() }
-    bind<Bar>() with singleton { Bar(foo = instance<Foo>()) }
+    bind<Foo>() { provider { Foo1() } }
+    bind<Bar>() { singleton { Bar(foo = instance<Foo>()) } }
 }
 
 val child = DI {
     extend(parent)
-    bind<Foo>(overrides = true) with provider { Foo2() }
+    bind<Foo>(overrides = true) { provider { Foo2() } }
 }
 
 val foo = child.instance<Bar>().foo
@@ -197,7 +197,7 @@ val child = DI {
     extend(parent, copy = Copy {
         copy the binding<Bar>() <1>
     })
-    bind<Foo>(overrides = true) with provider { Foo2() }
+    bind<Foo>(overrides = true) { provider { Foo2() } }
 }
 ----
 
@@ -210,14 +210,14 @@ If the binding you need to copy is bound by a context (such as a scoped singleto
 .Example: Copying a tagged scoped singleton
 ----
 val parent = DI {
-    bind<Session>(tag = "req") with scoped(requestScope).singleton { context.session() }
+    bind<Session>(tag = "req") { scoped(requestScope).singleton { context.session() } }
 }
 
 val child = DI {
     extend(parent, copy = Copy {
-        copy the binding<Session>() with scope(requestScope) and tag("req")
+        copy the binding<Session>() { scope(requestScope) and tag("req") }
     })
-    bind<Foo>(overrides = true) with provider { Foo2() }
+    bind<Foo>(overrides = true) { provider { Foo2() } }
 }
 ----
 

--- a/doc/modules/core/pages/multi-binding.adoc
+++ b/doc/modules/core/pages/multi-binding.adoc
@@ -35,20 +35,20 @@ You can:
 * Add bindings to the same set in different modules, provided that the set has been declared first.
 ====
 
-// TODO to be discussed
-//You can also bind multiple bindings with arguments (such as `factory` or `multiton`) in a set *as long as all bindings share the same argument type*.
-//
-//[source,kotlin]
-//.Example creating a set of `Result` bindings.
-//----
-//val di = DI {
-//    bindArgSet<Query, Result>()
-//
-//    inSet<Result> { factory { q: Query -> Foo.query(q) } }
-//    inSet<Result> { multiton { q: Query -> Bar.query(q) } }
-//}
-//----
+You can also bind multiple bindings with arguments (such as `factory` or `multiton`) in a set *as long as all bindings share the same argument type*.
 
+[source,kotlin]
+.Example creating a set of `Result` bindings.
+----
+val di = DI {
+    bindArgSet<Query, Result>() // <1>
+
+    inSet<Result> { factory { q: Query -> Foo.query(q) } } // <2>
+    inSet<Result> { multiton { q: Query -> Bar.query(q) } } // <2>
+}
+----
+<1> abc
+<2> abc
 
 === Retrieving from a Set
 
@@ -56,19 +56,18 @@ Note that the type being bound is `Set<T>`, not `T`. +
 Therefore, you need to retrieve a `Set`:
 
 [source,kotlin]
-.Example retrieving set of `Configuration` with the generic version.
+.Example retrieving set of `Configuration`.
 ----
 val configurations: Set<Configuration> by di.instance()
 ----
 
-if you are using the `erased` version, you need to retrieve thusly:
+To retrieve a `Set` with argument, thus going through a `factory` or a `multiton`, you need to pass the needed argument to the instance function.
 
 [source,kotlin]
-.Example retrieving set of `Configuration` with the erased version.
+.Example retrieving set of `Result` with `Query` argument.
 ----
-val configurations: Set<Configuration> by di.Instance(erasedSet())
+val result: Set<Result> by di.instance(arg = Query("SELECT * FROM USER;"))
 ----
-
 
 == In a map
 
@@ -92,8 +91,8 @@ Then, bind with keys:
 val di = DI {
     bindSet<ConfigurationEntry>()
 
-    inSet<ConfigurationEntry> { factory { "foo" to FooConfiguration() } }
-    inSet<ConfigurationEntry> { multiton { "bar" to BarConfiguration() } }
+    inSet<ConfigurationEntry> { singleton { "foo" to FooConfiguration() } }
+    inSet<ConfigurationEntry> { provider { "bar" to BarConfiguration() } }
 }
 ----
 

--- a/doc/modules/core/pages/multi-binding.adoc
+++ b/doc/modules/core/pages/multi-binding.adoc
@@ -18,10 +18,10 @@ To have multiple bindings in a set, you need to:
 .Example creating a set of `Configuration` bindings.
 ----
 val di = DI {
-    bind { setBinding<Configuration>() } <1>
+    bindSet<Configuration>() // <1>
 
-    bind<Configuration>().inSet() with provider { FooConfiguration() } // <2>
-    bind<Configuration>().inSet() with singleton { BarConfiguration() } // <2>
+    inSet<Configuration> { provider { FooConfiguration() } } // <2>
+    inSet<Configuration> { singleton { BarConfiguration() } } // <2>
 }
 ----
 <1> Creating a set binding of `Configuration`.
@@ -35,18 +35,19 @@ You can:
 * Add bindings to the same set in different modules, provided that the set has been declared first.
 ====
 
-You can also bind multiple bindings with arguments (such as `factory` or `multiton`) in a set *as long as all bindings share the same argument type*.
-
-[source,kotlin]
-.Example creating a set of `Result` bindings.
-----
-val di = DI {
-    bind { argSetBinding<Query, Result>() }
-
-    bind<Result>().inSet() with factory { q: Query -> Foo.query(q) }
-    bind<Result>().inSet() with multiton { q: Query -> Bar.query(q) }
-}
-----
+// TODO to be discussed
+//You can also bind multiple bindings with arguments (such as `factory` or `multiton`) in a set *as long as all bindings share the same argument type*.
+//
+//[source,kotlin]
+//.Example creating a set of `Result` bindings.
+//----
+//val di = DI {
+//    bindArgSet<Query, Result>()
+//
+//    inSet<Result> { factory { q: Query -> Foo.query(q) } }
+//    inSet<Result> { multiton { q: Query -> Bar.query(q) } }
+//}
+//----
 
 
 === Retrieving from a Set
@@ -89,10 +90,10 @@ Then, bind with keys:
 .Example binding as in a map multibinding.
 ----
 val di = DI {
-    bind { setBinding<ConfigurationEntry>() }
+    bindSet<ConfigurationEntry>()
 
-    bind<ConfigurationEntry>().inSet() with factory { "foo" to FooConfiguration() }
-    bind<ConfigurationEntry>().inSet() with multiton { "bar" to BarConfiguration() }
+    inSet<ConfigurationEntry> { factory { "foo" to FooConfiguration() } }
+    inSet<ConfigurationEntry> { multiton { "bar" to BarConfiguration() } }
 }
 ----
 

--- a/doc/modules/core/pages/multi-binding.adoc
+++ b/doc/modules/core/pages/multi-binding.adoc
@@ -18,7 +18,7 @@ To have multiple bindings in a set, you need to:
 .Example creating a set of `Configuration` bindings.
 ----
 val di = DI {
-    bind() from setBinding<Configuration>() <1>
+    bind { setBinding<Configuration>() } <1>
 
     bind<Configuration>().inSet() with provider { FooConfiguration() } // <2>
     bind<Configuration>().inSet() with singleton { BarConfiguration() } // <2>
@@ -41,7 +41,7 @@ You can also bind multiple bindings with arguments (such as `factory` or `multit
 .Example creating a set of `Result` bindings.
 ----
 val di = DI {
-    bind() from argSetBinding<Query, Result>()
+    bind { argSetBinding<Query, Result>() }
 
     bind<Result>().inSet() with factory { q: Query -> Foo.query(q) }
     bind<Result>().inSet() with multiton { q: Query -> Bar.query(q) }
@@ -89,7 +89,7 @@ Then, bind with keys:
 .Example binding as in a map multibinding.
 ----
 val di = DI {
-    bind() from setBinding<ConfigurationEntry>()
+    bind { setBinding<ConfigurationEntry>() }
 
     bind<ConfigurationEntry>().inSet() with factory { "foo" to FooConfiguration() }
     bind<ConfigurationEntry>().inSet() with multiton { "bar" to BarConfiguration() }

--- a/doc/modules/core/pages/using-environment.adoc
+++ b/doc/modules/core/pages/using-environment.adoc
@@ -26,7 +26,7 @@ TIP: When in doubt, use a factory with an argument instead of a provider with a 
 .Example: binding in a context
 ----
 val di = DI {
-    bind<Writer>() with contexted<Request>.provider { context.response.writer } // <1>
+    bind<Writer> { contexted<Request>.provider { context.response.writer } } // <1>
 }
 ----
 <1> note that `context` is already of type `Request`.
@@ -55,7 +55,7 @@ Therefore, the provided function will be called *once per session*.
 .Example: binding a User in a Session scope.
 ----
 val di = DI {
-    bind<User>() with scoped(SessionScope).singleton { UserData(session.userId) } // <1>
+    bind<User> { scoped(SessionScope).singleton { UserData(session.userId) } } // <1>
 }
 ----
 <1> note that `SessionScope` does not really exist, it is an example.
@@ -99,8 +99,10 @@ Yes, you can...
 .Example: JVM scoped weak references.
 ----
 val di = DI {
-    bind<User>() with scoped(requestScope).singleton(ref = weakReference) {
-        instance<DataSource>().createUser(context.session.id)
+    bind<User> {
+        scoped(requestScope).singleton(ref = weakReference) {
+            instance<DataSource>().createUser(context.session.id)
+        }
     } // <1>
 }
 ----
@@ -119,7 +121,7 @@ You can use this scope when it makes sense to have a scope on a context that is 
 .Example: controller scoped to an Activity with WeakContextScope.
 ----
 val di = DI {
-    bind<Controller>() with scoped(WeakContextScope.of<Activity>()).singleton { ControllerImpl(context) } // <1>
+    bind<Controller> { scoped(WeakContextScope.of<Activity>()).singleton { ControllerImpl(context) } } // <1>
 }
 ----
 <1> `context` is of type `Activity` because we are using the `WeakContextScope.of<Activity>()`.
@@ -145,7 +147,7 @@ As each `Request` is associated with a `Session`, you can register a context tra
 .Example:
 ----
 val di = DI {
-    bind<User>() with scoped(SessionScope).singleton { UserData(session.userId) }
+    bind<User> { scoped(SessionScope).singleton { UserData(session.userId) } }
 
     registerContextTranslator { r: Request -> r.session }
 }
@@ -182,9 +184,9 @@ You can access the container's bindings within a context translator:
 .Example:
 ----
 val di = DI {
-    bind<User>() with scoped(SessionScope).singleton { UserData(session.userId) }
+    bind<User> { scoped(SessionScope).singleton { UserData(session.userId) } }
 
-    bind<Translator>() with singleton { RequestTranslator() }
+    bind<Translator> { singleton { RequestTranslator() } }
     registerContextTranslator { r: Request ->
         instance<Translator>().translate(r)
      }
@@ -203,7 +205,7 @@ For example, if you are in a thread-based server where each request is assigned 
 .Example:
 ----
 val di = DI {
-    bind<User>() with scoped(SessionScope).singleton { UserData(session.userId) }
+    bind<User> { scoped(SessionScope).singleton { UserData(session.userId) } }
 
     registerContextFinder { ThreadLocalSession.get() }
 }
@@ -221,8 +223,8 @@ You can access the container's bindings within a context finder:
 enum class Env { DEBUG, PRODUCTION }
 class CurrentEnv(var env: Env)
 val di = DI {
-    bind() from scoped(EnvironmentScope).singleton { Service(context) }
-    bind() from singleton { CurrentEnv(Env.PRODUCTION) }
+    bind { scoped(EnvironmentScope).singleton { Service(context) } }
+    bind { singleton { CurrentEnv(Env.PRODUCTION) } }
     registerContextFinder { instance<CurrentEnv>().env }
 }
 ----

--- a/doc/modules/extension/pages/configurable.adoc
+++ b/doc/modules/extension/pages/configurable.adoc
@@ -31,7 +31,7 @@ enableFeaturePreview("GRADLE_METADATA")
 
 ====
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----
@@ -51,21 +51,7 @@ dependencies {
 }
 ----
 
-==== With Maven
-
-Add the JCenter repository:
-
-[source,xml,subs="attributes"]
-----
-&lt;repositories&gt;
-    &lt;repository&gt;
-      &lt;id&gt;jcenter&lt;/id&gt;
-      &lt;url&gt;https://jcenter.bintray.com&lt;/url&gt;
-    &lt;/repository&gt;
-&lt;/repositories&gt;
-----
-
-Then add the dependency:
+Add the dependency:
 
 [source,xml,subs="attributes"]
 ----
@@ -90,7 +76,7 @@ Because _Kodein-DI_ for JavaScript is compiled as a https://github.com/umdjs/umd
 ** Directly in an HTML page with a `<script>` tag (See index2.html in the demo project).
 * In NodeJS, as a regular CJS module.
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----
@@ -118,7 +104,7 @@ androidArm32, androidArm64, iosArm32, iosArm64, iosX64, linuxArm32Hfp, linuxMips
 
 _Kodein-DI_ uses the new gradle native dependency model.
 
-Add the JCenter repository:
+Add the MavenCentral repository:
 
 [source,groovy,subs="attributes"]
 ----

--- a/doc/modules/extension/pages/configurable.adoc
+++ b/doc/modules/extension/pages/configurable.adoc
@@ -146,8 +146,8 @@ fun test() {
     di.addExtend(otherDI)
 
     di.addConfig {
-        bind<Dice>() with provider { RandomDice(0, 5) }
-        bind<DataSource>() with singleton { SqliteDS.open("path/to/file") }
+        bind<Dice> { provider { RandomDice(0, 5) } }
+        bind<DataSource> { singleton { SqliteDS.open("path/to/file") } }
     }
 }
 ----

--- a/doc/modules/framework/pages/android.adoc
+++ b/doc/modules/framework/pages/android.adoc
@@ -6,6 +6,8 @@ NOTE: Kodein-DI does work on Android as-is.
       The `kodein-di-android` extension adds multiple android-specific utilities to Kodein-DI. +
       Using or not using this extension really depends on your needs.
 
+IMPORTANT: Starting from `7.4`, using Kodein-DI in your Android projects needs that you support Android 21 as the minimum SDK.
+
 Have a look at the https://github.com/Kodein-Framework/Kodein-Samples/tree/master/di/coffee-maker/android[Android demo project]!
 
 [[install]]

--- a/doc/modules/framework/pages/android.adoc
+++ b/doc/modules/framework/pages/android.adoc
@@ -237,7 +237,7 @@ The `WeakContextScope` will keep singleton and multiton instances as long as the
 .Example: using an Activity scope
 ----
 val di = DI {
-    bind<Controller>() with scoped(WeakContextScope.of<Activity>()).singleton { ControllerImpl(context) } // <1>
+    bind<Controller> { scoped(WeakContextScope.of<Activity>()).singleton { ControllerImpl(context) } } // <1>
 }
 ----
 <1> `context` is of type `Activity` because we are using the `WeakContextScope.of<Activity>()`.
@@ -257,7 +257,7 @@ CAUTION: This means that you *should never retain the activity* passed at creati
 .Example: using an Activity retained scope
 ----
 val di = DI {
-    bind<Controller>() with scoped(ActivityRetainedScope).singleton { ControllerImpl() }
+    bind<Controller> { scoped(ActivityRetainedScope).singleton { ControllerImpl() } }
 }
 ----
 
@@ -273,7 +273,7 @@ It uses Android support Lifecycle, so you need to use Android support's `Lifecyc
 .Example: using an Activity retained scope
 ----
 val di = DI {
-    bind<Controller>() with scoped(AndroidLifecycleScope<Fragment>()).singleton { ControllerImpl(context) }
+    bind<Controller> { scoped(AndroidLifecycleScope<Fragment>()).singleton { ControllerImpl(context) } }
 }
 ----
 

--- a/doc/modules/framework/pages/ktor.adoc
+++ b/doc/modules/framework/pages/ktor.adoc
@@ -64,7 +64,7 @@ Thus, the DI will be reachable from multiple places in your Ktor application.
 fun main(args: Array<String>) {
     embeddedServer(Netty, port = 8080) {
         di { // <1>
-            bind<Random>() with singleton { SecureRandom() } // <2>
+            bind<Random> { singleton { SecureRandom() } } // <2>
         }
    }.start(true)
 }
@@ -89,7 +89,7 @@ help us with that by defining a DI container that can be retrieve from multiple 
 fun main(args: Array<String>) {
     embeddedServer(Netty, port = 8080) {
         di { // <1>
-            bind<Random>() with singleton { SecureRandom() } // <2>
+            bind<Random> { singleton { SecureRandom() } } // <2>
         }
 
         routing {
@@ -165,13 +165,13 @@ To do so we have a function `subDI` available for the `Routing` / `Route` classe
 fun main(args: Array<String>) {
     embeddedServer(Netty, port = 8080) {
         di { // <1>
-            bind<Random>() with singleton { SecureRandom() } // <2>
+            bind<Random>() { singleton { SecureRandom() } } // <2>
         }
 
         routing {
             route("/login") {
                 subDI {
-                    bind<CredentialsDao> with singleton { CredentialsDao() } // <3>
+                    bind<CredentialsDao> { singleton { CredentialsDao() } } // <3>
                 }
 
                 post {
@@ -203,8 +203,8 @@ but we have the possibility to copy all the binding (including singleton / multi
 .Example: Copying all the bindings
 ----
 DI {
-    bind<Foo>() with provider { Foo("rootFoo") }
-    bind<Bar>() with singleton { Bar(instance()) }
+    bind<Foo> { provider { Foo("rootFoo") } }
+    bind<Bar> { singleton { Bar(instance()) } }
 }
 
 subDI(copy = Copy.All) { // <1>
@@ -223,15 +223,15 @@ Sometimes, It might be interesting to replace an existing dependency (by overrid
 .Example: overriding bindings
 ----
 DI {
-    bind<Foo>() with provider { Foo("rootFoo") }
-    bind<Bar>() with singleton { Bar(instance()) }
+    bind<Foo>() { provider { Foo("rootFoo") } }
+    bind<Bar>() { singleton { Bar(instance()) } }
 }
 
 subDI {
-    bind<Foo>(overrides = true) with provider { Foo("explicitFoo") } // <1>
+    bind<Foo>(overrides = true) { provider { Foo("explicitFoo") } } // <1>
 }
 subDI(allowSilentOverrides = true) { // <2>
-    bind<Foo> with provider { Foo("implicitFoo") }
+    bind<Foo> { provider { Foo("implicitFoo") } }
 }
 ----
 <1> Overriding the `Foo` binding
@@ -291,7 +291,7 @@ fun main(args: Array<String>) {
             cookie<UserSession>("SESSION_FEATURE_SESSION_ID") // <2>
         }
         di {
-            bind<Random>() with scoped(SessionScope).singleton { SecureRandom() } // <3>
+            bind<Random> { scoped(SessionScope).singleton { SecureRandom() } } // <3>
             /* binding */
         }
     }.start(true)
@@ -355,7 +355,7 @@ That's why the `CallScope` is just a wrapper upon `WeakContextScope` with the ta
 .Example: Defining call scoped dependencies
 ----
 val di = DI {
-    bind<Random>() with scoped(CallScope).singleton { SecureRandom() } // <1>
+    bind<Random> { scoped(CallScope).singleton { SecureRandom() } } // <1>
 }
 ----
 <1> A `Random` object will be created for each Request (HTTP or Websocket) and will be retrieved as long as the Request lives.

--- a/doc/modules/framework/pages/tornadofx.adoc
+++ b/doc/modules/framework/pages/tornadofx.adoc
@@ -248,7 +248,7 @@ For some need we could want to define DI containers into the `Node` hierarchy. T
 class MyView : View() {
     override val root = hbox { // <1>
         kodeinDI { // <2>
-            bind<Random>() with singleton { SecureRandom() }
+            bind<Random>() { singleton { SecureRandom() } }
         }
 
         form { // <3>
@@ -279,7 +279,7 @@ To do so, we have facilities to extend a DI container by calling the `subDI` ext
 ----
 class LoginController : Controller(), DIAware { // <1>
     override val di: DI = subDI { // <2>
-            bind<CredentialsDao> with singleton { CredentialsDao() } <3>
+            bind<CredentialsDao> { singleton { CredentialsDao() } } // <3>
     }
 
     // ...
@@ -302,11 +302,11 @@ NOTE: Making your `Component` as `DIAware` is *optional*, but it will help you k
 class LoginView : View() {
     override val root = hbox { // <1>
         subDI { // <2>
-            bind<LoginController>() with singleton { instance() } // <3>
+            bind<LoginController>() { singleton { instance() } } // <3>
         }
 
         form {
-            val controller by kodeinDI().instance<LoginController>() <4>
+            val controller by kodeinDI().instance<LoginController>() // <4>
         }
     }
 }
@@ -332,7 +332,7 @@ That's why the `ComponentScope` and `NodeScope` are just wrappers upon `WeakCont
 .Example: Defining `Component` scoped dependencies
 ----
 val di = DI {
-    bind<EditingState>() with scoped(ComponentScope).singleton { EditingState() } <1>
+    bind<EditingState>() { scoped(ComponentScope).singleton { EditingState() } } // <1>
 }
 ----
 <1> A `EditingState` object will be created for each Component that will ask for.
@@ -341,7 +341,7 @@ val di = DI {
 .Example: Retrieving `Component scoped dependencies
 ----
 class EditorTabFragment : Fragment() {
-    private val editingState: EditingState by kodeinDI().on(this).instance() <1>
+    private val editingState: EditingState by kodeinDI().on(this).instance() // <1>
 }
 ----
 <1> Scope is `this`
@@ -352,7 +352,7 @@ class EditorTabFragment : Fragment() {
 .Example: Defining `Node` scoped dependencies
 ----
 val di = DI {
-    bind<EditingState>() with scoped(NodeScope).singleton { EditingState() } <1>
+    bind<EditingState>() with scoped(NodeScope).singleton { EditingState() } // <1>
 }
 ----
 <1> A `EditingState` object will be created for each `Node` that will ask for.
@@ -365,7 +365,7 @@ class PersonEditorController : Controller() {
 
     fun editPerson(person: Person) {
         val tab = personEditorView.tabPane.tab("Tab Title")
-        val editingState: EditingState by kodeinDI().on(tab).instance() <1>
+        val editingState: EditingState by kodeinDI().on(tab).instance() // <1>
     }
 }
 ----

--- a/framework/android/kodein-di-framework-android-core/src/main/java/org/kodein/di/android/module.kt
+++ b/framework/android/kodein-di-framework-android-core/src/main/java/org/kodein/di/android/module.kt
@@ -50,6 +50,7 @@ import android.view.accessibility.CaptioningManager
 import android.view.inputmethod.InputMethodManager
 import android.view.textservice.TextServicesManager
 import org.kodein.di.DI
+import org.kodein.di.bind
 import org.kodein.di.bindings.*
 import org.kodein.type.TypeToken
 import org.kodein.type.generic
@@ -76,18 +77,25 @@ fun androidCoreModule(app: Application) = DI.Module(name = "\u2063androidModule"
 
     val contextToken = generic<Context>()
 
-    Bind() from Provider(TypeToken.Any, generic()) { app }
+    Bind { Provider(TypeToken.Any, generic()) { app } }
 
-    Bind() from Provider(contextToken, generic()) { context.assets }
-    Bind() from Provider(contextToken, generic()) { context.contentResolver }
-    Bind() from Provider(contextToken, generic()) { context.applicationInfo }
-    Bind() from Provider(contextToken, generic()) { context.mainLooper }
-    Bind() from Provider(contextToken, generic()) { context.packageManager }
-    Bind() from Provider(contextToken, generic()) { context.resources }
-    Bind() from Provider(contextToken, generic()) { context.theme }
+    Bind { Provider(contextToken, generic()) { context.assets } }
+    Bind { Provider(contextToken, generic()) { context.contentResolver } }
+    Bind { Provider(contextToken, generic()) { context.applicationInfo } }
+    Bind { Provider(contextToken, generic()) { context.mainLooper } }
+    Bind { Provider(contextToken, generic()) { context.packageManager } }
+    Bind { Provider(contextToken, generic()) { context.resources } }
+    Bind { Provider(contextToken, generic()) { context.theme } }
 
-    Bind() from Provider(contextToken, generic()) { PreferenceManager.getDefaultSharedPreferences(context) }
-    Bind() from Factory(contextToken, generic(), generic()) { name: String -> context.getSharedPreferences(name, Context.MODE_PRIVATE) }
+    Bind { Provider(contextToken, generic()) { PreferenceManager.getDefaultSharedPreferences(context) } }
+    Bind {
+        Factory(contextToken, generic(), generic()) { name: String ->
+            context.getSharedPreferences(
+                name,
+                Context.MODE_PRIVATE
+            )
+        }
+    }
 
     Bind<File>(generic(), tag = "cache") with Provider(contextToken, generic()) { context.cacheDir }
     // Bind<File>(generic(), tag = "externalCache") with Provider(contextToken, generic()) { context.externalCacheDir } TODO: re-enable once we found how to bind nullables
@@ -98,89 +106,67 @@ fun androidCoreModule(app: Application) = DI.Module(name = "\u2063androidModule"
     Bind<String>(generic(), tag = "packageName") with Provider(contextToken, generic()) { context.packageName }
     Bind<String>(generic(), tag = "packageResourcePath") with Provider(contextToken, generic()) { context.packageResourcePath }
 
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.ACCOUNT_SERVICE) as AccountManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.ALARM_SERVICE) as AlarmManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.DROPBOX_SERVICE) as DropBoxManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.LOCATION_SERVICE) as LocationManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.NFC_SERVICE) as NfcManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.POWER_SERVICE) as PowerManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.SEARCH_SERVICE) as SearchManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.STORAGE_SERVICE) as StorageManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.TEXT_SERVICES_MANAGER_SERVICE) as TextServicesManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.USB_SERVICE) as UsbManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.WALLPAPER_SERVICE) as WallpaperManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_P2P_SERVICE) as WifiP2pManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_SERVICE) as WifiManager }
-    Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.WINDOW_SERVICE) as WindowManager }
-
-    if (Build.VERSION.SDK_INT >= 16) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.INPUT_SERVICE) as InputManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_ROUTER_SERVICE) as MediaRouter }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.NSD_SERVICE) as NsdManager }
-    }
-
-    if (Build.VERSION.SDK_INT >= 17) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.USER_SERVICE) as UserManager }
-    }
-
-    if (Build.VERSION.SDK_INT >= 18) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager }
-    }
-
-    if (Build.VERSION.SDK_INT >= 19) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.CAPTIONING_SERVICE) as CaptioningManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.CONSUMER_IR_SERVICE) as ConsumerIrManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.PRINT_SERVICE) as PrintManager }
-    }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACCOUNT_SERVICE) as AccountManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ALARM_SERVICE) as AlarmManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.DROPBOX_SERVICE) as DropBoxManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.LOCATION_SERVICE) as LocationManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.NFC_SERVICE) as NfcManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.POWER_SERVICE) as PowerManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SEARCH_SERVICE) as SearchManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.STORAGE_SERVICE) as StorageManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TEXT_SERVICES_MANAGER_SERVICE) as TextServicesManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.USB_SERVICE) as UsbManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WALLPAPER_SERVICE) as WallpaperManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_P2P_SERVICE) as WifiP2pManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_SERVICE) as WifiManager } }
+    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WINDOW_SERVICE) as WindowManager } }
 
     if (Build.VERSION.SDK_INT >= 21) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.APPWIDGET_SERVICE) as AppWidgetManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.CAMERA_SERVICE) as CameraManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.TV_INPUT_SERVICE) as TvInputManager }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.APPWIDGET_SERVICE) as AppWidgetManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CAMERA_SERVICE) as CameraManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TV_INPUT_SERVICE) as TvInputManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 22) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 23) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.CARRIER_CONFIG_SERVICE) as CarrierConfigManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.MIDI_SERVICE) as MidiManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.NETWORK_STATS_SERVICE) as NetworkStatsManager }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CARRIER_CONFIG_SERVICE) as CarrierConfigManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.MIDI_SERVICE) as MidiManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.NETWORK_STATS_SERVICE) as NetworkStatsManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 24) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.HARDWARE_PROPERTIES_SERVICE) as HardwarePropertiesManager }
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.SYSTEM_HEALTH_SERVICE) as SystemHealthManager }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.HARDWARE_PROPERTIES_SERVICE) as HardwarePropertiesManager } }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SYSTEM_HEALTH_SERVICE) as SystemHealthManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 25) {
-        Bind() from Provider(contextToken, generic()) { context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager }
+        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager } }
     }
 }

--- a/framework/android/kodein-di-framework-android-core/src/main/java/org/kodein/di/android/module.kt
+++ b/framework/android/kodein-di-framework-android-core/src/main/java/org/kodein/di/android/module.kt
@@ -77,18 +77,18 @@ fun androidCoreModule(app: Application) = DI.Module(name = "\u2063androidModule"
 
     val contextToken = generic<Context>()
 
-    Bind { Provider(TypeToken.Any, generic()) { app } }
+    bind { Provider(TypeToken.Any, generic()) { app } }
 
-    Bind { Provider(contextToken, generic()) { context.assets } }
-    Bind { Provider(contextToken, generic()) { context.contentResolver } }
-    Bind { Provider(contextToken, generic()) { context.applicationInfo } }
-    Bind { Provider(contextToken, generic()) { context.mainLooper } }
-    Bind { Provider(contextToken, generic()) { context.packageManager } }
-    Bind { Provider(contextToken, generic()) { context.resources } }
-    Bind { Provider(contextToken, generic()) { context.theme } }
+    bind { Provider(contextToken, generic()) { context.assets } }
+    bind { Provider(contextToken, generic()) { context.contentResolver } }
+    bind { Provider(contextToken, generic()) { context.applicationInfo } }
+    bind { Provider(contextToken, generic()) { context.mainLooper } }
+    bind { Provider(contextToken, generic()) { context.packageManager } }
+    bind { Provider(contextToken, generic()) { context.resources } }
+    bind { Provider(contextToken, generic()) { context.theme } }
 
-    Bind { Provider(contextToken, generic()) { PreferenceManager.getDefaultSharedPreferences(context) } }
-    Bind {
+    bind { Provider(contextToken, generic()) { PreferenceManager.getDefaultSharedPreferences(context) } }
+    bind {
         Factory(contextToken, generic(), generic()) { name: String ->
             context.getSharedPreferences(
                 name,
@@ -106,67 +106,67 @@ fun androidCoreModule(app: Application) = DI.Module(name = "\u2063androidModule"
     Bind<String>(generic(), tag = "packageName") with Provider(contextToken, generic()) { context.packageName }
     Bind<String>(generic(), tag = "packageResourcePath") with Provider(contextToken, generic()) { context.packageResourcePath }
 
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACCOUNT_SERVICE) as AccountManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.ALARM_SERVICE) as AlarmManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.DROPBOX_SERVICE) as DropBoxManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.LOCATION_SERVICE) as LocationManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.NFC_SERVICE) as NfcManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.POWER_SERVICE) as PowerManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SEARCH_SERVICE) as SearchManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.STORAGE_SERVICE) as StorageManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TEXT_SERVICES_MANAGER_SERVICE) as TextServicesManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.USB_SERVICE) as UsbManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WALLPAPER_SERVICE) as WallpaperManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_P2P_SERVICE) as WifiP2pManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_SERVICE) as WifiManager } }
-    Bind { Provider(contextToken, generic()) { context.getSystemService(Context.WINDOW_SERVICE) as WindowManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACCOUNT_SERVICE) as AccountManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.ALARM_SERVICE) as AlarmManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.AUDIO_SERVICE) as AudioManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.DROPBOX_SERVICE) as DropBoxManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.LOCATION_SERVICE) as LocationManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.NFC_SERVICE) as NfcManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.POWER_SERVICE) as PowerManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.SEARCH_SERVICE) as SearchManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.SENSOR_SERVICE) as SensorManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.STORAGE_SERVICE) as StorageManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.TEXT_SERVICES_MANAGER_SERVICE) as TextServicesManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.USB_SERVICE) as UsbManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.WALLPAPER_SERVICE) as WallpaperManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_P2P_SERVICE) as WifiP2pManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.WIFI_SERVICE) as WifiManager } }
+    bind { Provider(contextToken, generic()) { context.getSystemService(Context.WINDOW_SERVICE) as WindowManager } }
 
     if (Build.VERSION.SDK_INT >= 21) {
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.APPWIDGET_SERVICE) as AppWidgetManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CAMERA_SERVICE) as CameraManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TV_INPUT_SERVICE) as TvInputManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.APPWIDGET_SERVICE) as AppWidgetManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.CAMERA_SERVICE) as CameraManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.TV_INPUT_SERVICE) as TvInputManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 22) {
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE) as SubscriptionManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 23) {
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.CARRIER_CONFIG_SERVICE) as CarrierConfigManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.MIDI_SERVICE) as MidiManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.NETWORK_STATS_SERVICE) as NetworkStatsManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.CARRIER_CONFIG_SERVICE) as CarrierConfigManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.MIDI_SERVICE) as MidiManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.NETWORK_STATS_SERVICE) as NetworkStatsManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 24) {
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.HARDWARE_PROPERTIES_SERVICE) as HardwarePropertiesManager } }
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SYSTEM_HEALTH_SERVICE) as SystemHealthManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.HARDWARE_PROPERTIES_SERVICE) as HardwarePropertiesManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.SYSTEM_HEALTH_SERVICE) as SystemHealthManager } }
     }
 
     if (Build.VERSION.SDK_INT >= 25) {
-        Bind { Provider(contextToken, generic()) { context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager } }
+        bind { Provider(contextToken, generic()) { context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager } }
     }
 }

--- a/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorApplication.kt
+++ b/framework/ktor/kodein-di-framework-ktor-server-jvm/src/test/kotlin/org/kodein/di/ktor/KtorApplication.kt
@@ -14,8 +14,8 @@ fun Application.main() {
     install(DefaultHeaders)
 
     di {
-        bind() from scoped(SessionScope).singleton { Random() }
-        bind() from scoped(CallScope).singleton { Random() }
+        bind { scoped(SessionScope).singleton { Random() } }
+        bind { scoped(CallScope).singleton { Random() } }
 
         constant("author") with AUTHOR.toLowerCase()
     }

--- a/kodein-di-conf/src/commonTest/kotlin/org/kodein/di/conf/ConfTests.kt
+++ b/kodein-di-conf/src/commonTest/kotlin/org/kodein/di/conf/ConfTests.kt
@@ -165,7 +165,8 @@ class ConfTests {
         var ready = false
 
         di.addConfig {
-            bind() from singleton { "test" }
+            bind()
+            bind { singleton { "test" } }
 
             onReady {
                 ready = true

--- a/kodein-di-conf/src/jvmTest/kotlin/org/kodein/di/conf/test/ConfJvmTests.kt
+++ b/kodein-di-conf/src/jvmTest/kotlin/org/kodein/di/conf/test/ConfJvmTests.kt
@@ -77,7 +77,7 @@ class ConfJvmTests {
         assertNull(di.direct.instanceOrNull<String>())
 
         di.addConfig {
-            bind() from provider { "def" }
+            bind { provider { "def" } }
         }
 
         assertEquals("bar", di.direct.instance(tag = "foo"))

--- a/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/jxInjectorModule.kt
+++ b/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/jxInjectorModule.kt
@@ -11,7 +11,7 @@ import javax.inject.Named
  * Module that must be imported in order to use [JxInjector].
  */
 public val jxInjectorModule: DI.Module = DI.Module("JX Injector") {
-    bind { SetBinding<Any, JxInjectorContainer.Qualifier>(TypeToken.Any, erased(), erasedSet()) }
+    Bind(binding = SetBinding<Any, JxInjectorContainer.Qualifier>(TypeToken.Any, erased(), erasedSet()))
     jxQualifier(Named::class.java) { it.value }
 
     bind<JxInjectorContainer>() with Singleton(NoScope(), erased(), false, erased()) { JxInjectorContainer(Instance(erasedSet())) }

--- a/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/jxInjectorModule.kt
+++ b/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/jxInjectorModule.kt
@@ -11,7 +11,7 @@ import javax.inject.Named
  * Module that must be imported in order to use [JxInjector].
  */
 public val jxInjectorModule: DI.Module = DI.Module("JX Injector") {
-    Bind() from SetBinding<Any, JxInjectorContainer.Qualifier>(TypeToken.Any, erased(), erasedSet())
+    bind { SetBinding<Any, JxInjectorContainer.Qualifier>(TypeToken.Any, erased(), erasedSet()) }
     jxQualifier(Named::class.java) { it.value }
 
     bind<JxInjectorContainer>() with Singleton(NoScope(), erased(), false, erased()) { JxInjectorContainer(Instance(erasedSet())) }

--- a/kodein-di-jxinject-jvm/src/test/kotlin/org/kodein/di/jxinject/kodeins.kt
+++ b/kodein-di-jxinject-jvm/src/test/kotlin/org/kodein/di/jxinject/kodeins.kt
@@ -5,8 +5,8 @@ import org.kodein.di.*
 fun test0() = DI {
     import(jxInjectorModule)
 
-    bind() from instance("Salomon")
-    bind(tag = "lastname") from instance("BRYS")
+    bind { instance("Salomon") }
+    bind(tag = "lastname") { instance("BRYS") }
     bind<List<String>>() with instance(listOf("a", "b", "c"))
     bind<Set<String>>() with instance(setOf("a", "b", "c"))
 }
@@ -16,8 +16,8 @@ fun test1() = DI.direct {
 
     var count = 0
 
-    bind() from provider { "Salomon ${count++}" }
-    bind(tag = "lastname") from provider { "BRYS ${count++}" }
+    bind { provider { "Salomon ${count++}" } }
+    bind(tag = "lastname") { provider { "BRYS ${count++}" } }
     bind<List<String>>() with provider { listOf("a", "b", "c") }
     bind<Set<String>>() with provider { setOf("a", "b", "c") }
 }
@@ -25,14 +25,14 @@ fun test1() = DI.direct {
 fun test2() = DI {
     import(jxInjectorModule)
 
-    bind() from factory { i: Int -> "Salomon $i" }
-    bind(tag = "lastname") from factory { i: Int -> "BRYS $i" }
+    bind { factory { i: Int -> "Salomon $i" } }
+    bind(tag = "lastname") { factory { i: Int -> "BRYS $i" } }
     bind<List<String>>() with factory { i: Int -> listOf("a$i", "b$i", "c$i") }
     bind<Set<String>>() with factory { i: Int -> setOf("a$i", "b$i", "c$i") }
 }
 
 fun test4() = DI.direct {
-    bind(tag = "universe:answer") from instance("fourty-two")
+    bind(tag = "universe:answer") { instance("fourty-two") }
 
     import(jxInjectorModule)
 

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/BindingsMap.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/BindingsMap.kt
@@ -31,7 +31,7 @@ private fun BindingsMap.descriptionImpl(withOverrides: Boolean, ident: Int, keyB
     fun StringBuilder.appendBindings(ident: Int, entries: List<Map.Entry<DI.Key<*, *, *>, List<DIDefinition<*, *, *>>>>) =
             entries.forEach {
                 val keyDescription = it.key.keyBindDisp()
-                append("${" ".repeat(ident)}$keyDescription with ${it.value.first().binding.bindingDisp()}")
+                append("${" ".repeat(ident)}$keyDescription { ${it.value.first().binding.bindingDisp()} }")
                 if (withOverrides) {
                     val subIdent = keyDescription.length - 4
                     it.value.subList(1, it.value.size).forEach {

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
@@ -260,7 +260,7 @@ public interface DI : DIAware {
          * @param tag The tag to bind.
          * @param overrides Whether this bind **must** or **must not** override an existing binding.
          */
-        public fun <T : Any> Bind(tag: Any? = null, overrides: Boolean? = null, createBinding: () -> DIBinding<*, *, T>)
+        public fun <T : Any> Bind(tag: Any? = null, overrides: Boolean? = null, binding: DIBinding<*, *, T>)
 
         /**
          * Starts the binding of a given type with a given tag.

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
@@ -107,7 +107,7 @@ public interface DI : DIAware {
          * @param dispString a function that gets the display string for a type.
          */
         private fun StringBuilder.appendDescription(dispString: TypeToken<*>.() -> String) {
-            append(" with ")
+            append(" { ")
             if (contextType != TypeToken.Any) {
                 append("?<${contextType.dispString()}>().")
             }
@@ -117,18 +117,19 @@ public interface DI : DIAware {
                 append(" -> ")
             }
             append("? }")
+            append(" }")
         }
 
 
         /**
          * Description using simple type names. The description is as close as possible to the code used to create this bind.
          */
-        val bindDescription: String get() = "bind<${type.simpleDispString()}>(${ if (tag != null) "tag = \"$tag\"" else "" })"
+        val bindDescription: String get() = "bind<${type.simpleDispString()}>${ if (tag != null) "(tag = \"$tag\")" else "" }"
 
         /**
          * Description using full type names. The description is as close as possible to the code used to create this bind.
          */
-        val bindFullDescription: String get() = "bind<${type.qualifiedDispString()}>(${ if (tag != null) "tag = \"$tag\"" else "" })"
+        val bindFullDescription: String get() = "bind<${type.qualifiedDispString()}>${ if (tag != null) "(tag = \"$tag\")" else "" }"
 
         /**
          * Description using simple type names. The description is as close as possible to the code used to create this key.

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
@@ -232,6 +232,7 @@ public interface DI : DIAware {
              * @param binding The binding to bind.
              * @throws OverridingException If this bindings overrides an existing binding and is not allowed to.
              */
+            @Deprecated("'bind() fron [BINDING]' might be replace by 'bind { [BINDING] }' (This will be remove in Kodein-DI 8.0)", replaceWith = ReplaceWith("bind { binding }"))
             public infix fun <C : Any, A, T: Any> from(binding: DIBinding<in C, in A, out T>)
         }
 
@@ -251,6 +252,15 @@ public interface DI : DIAware {
             @Suppress("FunctionName")
             public fun <T: Any> With(valueType: TypeToken<out T>, value: T)
         }
+
+        /**
+         * Attaches the binding of a given type with a given tag.
+         *
+         * @param T The type of value to bind.
+         * @param tag The tag to bind.
+         * @param overrides Whether this bind **must** or **must not** override an existing binding.
+         */
+        public fun <T : Any> Bind(tag: Any? = null, overrides: Boolean? = null, createBinding: () -> DIBinding<*, *, T>)
 
         /**
          * Starts the binding of a given type with a given tag.

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DI.kt
@@ -1,9 +1,6 @@
 package org.kodein.di
 
-import org.kodein.di.bindings.ContextTranslator
-import org.kodein.di.bindings.ExternalSource
-import org.kodein.di.bindings.DIBinding
-import org.kodein.di.bindings.Scope
+import org.kodein.di.bindings.*
 import org.kodein.di.internal.DIImpl
 import org.kodein.type.TypeToken
 import kotlin.native.concurrent.ThreadLocal
@@ -262,6 +259,15 @@ public interface DI : DIAware {
          * @param overrides Whether this bind **must** or **must not** override an existing binding.
          */
         public fun <T : Any> Bind(tag: Any? = null, overrides: Boolean? = null, binding: DIBinding<*, *, T>)
+
+        /**
+         * Attaches the binding of a given type with a given tag.
+         *
+         * @param T The type of value to bind.
+         * @param tag The tag to bind.
+         * @param overrides Whether this bind **must** or **must not** override an existing binding.
+         */
+        public fun <T : Any> BindSet(tag: Any? = null, overrides: Boolean? = null, binding: DIBinding<*, *, T>)
 
         /**
          * Starts the binding of a given type with a given tag.

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
@@ -14,7 +14,7 @@ import org.kodein.type.generic
  * @param T The created type.
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
-public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: DirectDI.() -> T): Unit = Bind(binding = singleton(creator = creator))
+public inline fun <reified T: Any> DI.Builder.bindSingleton(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.() -> T): Unit = Bind(tag, overrides, singleton(creator = creator))
 
 /**
  * Binds a multiton: will create an instance on first request and will subsequently always return the same instance.
@@ -24,7 +24,7 @@ public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: Di
  * @param T The created type.
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
-public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(sync: Boolean = true, noinline creator: DirectDI.(A) -> T): Unit = Bind(binding = multiton(sync = sync, creator = creator))
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(tag: Any? = null, overrides: Boolean? = null, sync: Boolean = true, noinline creator: DirectDI.(A) -> T): Unit = Bind(tag, overrides, multiton(sync = sync, creator = creator))
 
 
 /**
@@ -37,7 +37,7 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(sync
  * @param T The created type.
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
-public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: DirectDI.() -> T): Unit = Bind(binding = provider(creator = creator))
+public inline fun <reified T: Any> DI.Builder.bindProvider(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.() -> T): Unit = Bind(tag, overrides, provider(creator = creator))
 
 /**
  * Binds a factory: each time an instance is needed, the function [creator] function will be called.
@@ -48,7 +48,7 @@ public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: Dir
  * @param T The created type.
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
-public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinline creator: DirectDI.(A) -> T): Unit = Bind(binding = factory(creator = creator))
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.(A) -> T): Unit = Bind(tag, overrides, factory(creator = creator))
 
 /**
  * Binds an instance provider: will always return the given instance.
@@ -58,7 +58,17 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinl
  * @param T The type of the instance.
  * @param instance The object that will always be returned.
  */
-public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T): Unit = Bind(binding = instance(instance))
+public inline fun <reified T: Any> DI.Builder.bindInstance(tag: Any? = null, overrides: Boolean? = null, creator: () -> T): Unit = Bind(tag, overrides, instance(creator()))
+
+/**
+ * Binds a constant provider: will always return the given instance.
+ *
+ * T generics will be erased!
+ *
+ * @param T The type of the instance.
+ * @param instance The object that will always be returned.
+ */
+public inline fun <reified T: Any> DI.Builder.bindConstant(tag: Any, overrides: Boolean? = null, creator: () -> T): Unit = constant(tag, overrides) with creator()
 
 /**
  * Attaches a binding to the DI container

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
@@ -4,7 +4,61 @@ import org.kodein.di.bindings.*
 import org.kodein.type.generic
 
 
-//region Standard bindings
+//region Simple bindings
+/**
+ * Binds a singleton: will create an instance on first request and will subsequently always return the same instance.
+ *
+ * T generics will be erased!
+ *
+ * @param T The created type.
+ * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
+ */
+public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: DirectDI.() -> T) {
+    bind<T>() with singleton(creator = creator)
+}
+
+
+/**
+ * Creates a factory: each time an instance is needed, the function [creator] function will be called.
+ *
+ * T generics will be erased!
+ *
+ * A provider is like a [factory], but without argument.
+ *
+ * @param T The created type.
+ * @param creator The function that will be called each time an instance is requested. Should create a new instance.
+ */
+public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: DirectDI.() -> T) {
+    bind<T>() with provider(creator = creator)
+}
+
+/**
+ * Binds a factory: each time an instance is needed, the function [creator] function will be called.
+ *
+ * A & T generics will be erased!
+ *
+ * @param A The argument type.
+ * @param T The created type.
+ * @param creator The function that will be called each time an instance is requested. Should create a new instance.
+ */
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinline creator: DirectDI.(A) -> T) {
+    bind<T>() with factory(creator = creator)
+}
+
+/**
+ * Binds an instance provider: will always return the given instance.
+ *
+ * T generics will be erased!
+ *
+ * @param T The type of the instance.
+ * @param instance The object that will always be returned.
+ */
+public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T) {
+    bind<T>() with instance(instance)
+}
+//endregion
+
+//region Advanced bindings
 /**
  * Starts the binding of a given type with a given tag.
  *

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
@@ -1,6 +1,7 @@
 package org.kodein.di
 
 import org.kodein.di.bindings.*
+import org.kodein.type.TypeToken
 import org.kodein.type.generic
 
 
@@ -14,7 +15,19 @@ import org.kodein.type.generic
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
 public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: DirectDI.() -> T) {
-    bind<T>() with singleton(creator = creator)
+    bind { singleton(creator = creator) }
+}
+
+/**
+ * Binds a multiton: will create an instance on first request and will subsequently always return the same instance.
+ *
+ * T generics will be erased!
+ *
+ * @param T The created type.
+ * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
+ */
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(sync: Boolean = true, noinline creator: DirectDI.(A) -> T) {
+    bind { multiton(sync = sync, creator = creator) }
 }
 
 
@@ -29,7 +42,7 @@ public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: Di
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
 public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: DirectDI.() -> T) {
-    bind<T>() with provider(creator = creator)
+    bind { provider(creator = creator) }
 }
 
 /**
@@ -42,7 +55,7 @@ public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: Dir
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
 public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinline creator: DirectDI.(A) -> T) {
-    bind<T>() with factory(creator = creator)
+    bind { factory(creator = creator) }
 }
 
 /**
@@ -54,8 +67,17 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinl
  * @param instance The object that will always be returned.
  */
 public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T) {
-    bind<T>() with instance(instance)
+    bind { instance(instance) }
 }
+
+/**
+ * Attaches a binding to the DI container
+ *
+ * @param T The type of value to bind.
+ * @param tag The tag to bind.
+ * @param overrides Whether this bind **must** or **must not** override an existing binding.
+ */
+public inline fun <reified T: Any> DI.Builder.bind(tag: Any? = null, overrides: Boolean? = null, noinline createBinding: () -> DIBinding<*, *, T>): Unit = Bind(tag, overrides, createBinding)
 //endregion
 
 //region Advanced bindings
@@ -78,6 +100,7 @@ public inline fun <reified T : Any> DI.Builder.bind(tag: Any? = null, overrides:
  * @param overrides Whether this bind **must**, **may** or **must not** override an existing binding.
  * @return The binder: call [DI.Builder.DirectBinder.from]) on it to finish the binding syntax and register the binding.
  */
+@Deprecated("'bind() fron [BINDING]' might be replace by 'bind { [BINDING] }' (This will be remove in Kodein-DI 8.0)")
 public fun DI.Builder.bind(tag: Any? = null, overrides: Boolean? = null): DI.Builder.DirectBinder = Bind(tag, overrides)
 
 /**

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
@@ -14,9 +14,7 @@ import org.kodein.type.generic
  * @param T The created type.
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
-public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: DirectDI.() -> T) {
-    bind { singleton(creator = creator) }
-}
+public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: DirectDI.() -> T): Unit = Bind(binding = singleton(creator = creator))
 
 /**
  * Binds a multiton: will create an instance on first request and will subsequently always return the same instance.
@@ -26,9 +24,7 @@ public inline fun <reified T: Any> DI.Builder.bindSingleton(noinline creator: Di
  * @param T The created type.
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
-public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(sync: Boolean = true, noinline creator: DirectDI.(A) -> T) {
-    bind { multiton(sync = sync, creator = creator) }
-}
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(sync: Boolean = true, noinline creator: DirectDI.(A) -> T): Unit = Bind(binding = multiton(sync = sync, creator = creator))
 
 
 /**
@@ -41,9 +37,7 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(sync
  * @param T The created type.
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
-public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: DirectDI.() -> T) {
-    bind { provider(creator = creator) }
-}
+public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: DirectDI.() -> T): Unit = Bind(binding = provider(creator = creator))
 
 /**
  * Binds a factory: each time an instance is needed, the function [creator] function will be called.
@@ -54,9 +48,7 @@ public inline fun <reified T: Any> DI.Builder.bindProvider(noinline creator: Dir
  * @param T The created type.
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
-public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinline creator: DirectDI.(A) -> T) {
-    bind { factory(creator = creator) }
-}
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinline creator: DirectDI.(A) -> T): Unit = Bind(binding = factory(creator = creator))
 
 /**
  * Binds an instance provider: will always return the given instance.
@@ -66,9 +58,7 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(noinl
  * @param T The type of the instance.
  * @param instance The object that will always be returned.
  */
-public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T) {
-    bind { instance(instance) }
-}
+public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T): Unit = Bind(binding = instance(instance))
 
 /**
  * Attaches a binding to the DI container
@@ -77,7 +67,7 @@ public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T) {
  * @param tag The tag to bind.
  * @param overrides Whether this bind **must** or **must not** override an existing binding.
  */
-public inline fun <reified T: Any> DI.Builder.bind(tag: Any? = null, overrides: Boolean? = null, noinline createBinding: () -> DIBinding<*, *, T>): Unit = Bind(tag, overrides, createBinding)
+public inline fun <reified T: Any> DI.Builder.bind(tag: Any? = null, overrides: Boolean? = null, noinline createBinding: () -> DIBinding<*, *, T>): Unit = Bind(tag, overrides, createBinding())
 //endregion
 
 //region Advanced bindings

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
@@ -1,8 +1,6 @@
 package org.kodein.di
 
 import org.kodein.di.bindings.*
-import org.kodein.di.internal.DIBuilderImpl
-import org.kodein.type.TypeToken
 import org.kodein.type.generic
 
 
@@ -15,7 +13,7 @@ import org.kodein.type.generic
  * @param T The created type.
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
-public inline fun <reified T: Any> DI.Builder.bindSingleton(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.() -> T): Unit = Bind(tag, overrides, singleton(creator = creator))
+public inline fun <reified T: Any> DI.Builder.bindSingleton(tag: Any? = null, overrides: Boolean? = null, sync: Boolean = true, noinline creator: DirectDI.() -> T): Unit = Bind(tag = tag, overrides = overrides, binding = singleton(sync = sync, creator = creator))
 
 /**
  * Binds a multiton: will create an instance on first request and will subsequently always return the same instance.
@@ -25,7 +23,7 @@ public inline fun <reified T: Any> DI.Builder.bindSingleton(tag: Any? = null, ov
  * @param T The created type.
  * @param creator The function that will be called the first time an instance is requested. Guaranteed to be called only once. Should create a new instance.
  */
-public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(tag: Any? = null, overrides: Boolean? = null, sync: Boolean = true, noinline creator: DirectDI.(A) -> T): Unit = Bind(tag, overrides, multiton(sync = sync, creator = creator))
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(tag: Any? = null, overrides: Boolean? = null, sync: Boolean = true, noinline creator: DirectDI.(A) -> T): Unit = Bind(tag = tag, overrides = overrides, binding = multiton(sync = sync, creator = creator))
 
 
 /**
@@ -38,7 +36,7 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindMultiton(tag:
  * @param T The created type.
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
-public inline fun <reified T: Any> DI.Builder.bindProvider(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.() -> T): Unit = Bind(tag, overrides, provider(creator = creator))
+public inline fun <reified T: Any> DI.Builder.bindProvider(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.() -> T): Unit = Bind(tag = tag, overrides = overrides, binding = provider(creator = creator))
 
 /**
  * Binds a factory: each time an instance is needed, the function [creator] function will be called.
@@ -49,7 +47,7 @@ public inline fun <reified T: Any> DI.Builder.bindProvider(tag: Any? = null, ove
  * @param T The created type.
  * @param creator The function that will be called each time an instance is requested. Should create a new instance.
  */
-public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.(A) -> T): Unit = Bind(tag, overrides, factory(creator = creator))
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(tag: Any? = null, overrides: Boolean? = null, noinline creator: DirectDI.(A) -> T): Unit = Bind(tag = tag, overrides = overrides, binding = factory(creator = creator))
 
 /**
  * Binds an instance provider: will always return the given instance.
@@ -57,19 +55,19 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(tag: 
  * T generics will be erased!
  *
  * @param T The type of the instance.
- * @param instance The object that will always be returned.
+ * @param creator A function that must the instance of type T.
  */
-public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T): Unit = Bind(binding = instance(instance))
+public inline fun <reified T: Any> DI.Builder.bindInstance(tag: Any? = null, overrides: Boolean? = null, creator: () -> T): Unit = Bind(tag = tag, overrides = overrides, binding = instance(creator()))
 
 /**
  * Binds a constant provider: will always return the given instance.
  *
  * T generics will be erased!
  *
- * @param T The type of the instance.
- * @param instance The object that will always be returned.
+ * @param T The type of the constant.
+ * @param creator A function that must the constant of type T.
  */
-public inline fun <reified T: Any> DI.Builder.bindConstant(tag: Any, overrides: Boolean? = null, creator: () -> T): Unit = constant(tag, overrides) with creator()
+public inline fun <reified T: Any> DI.Builder.bindConstant(tag: Any, overrides: Boolean? = null, creator: () -> T): Unit = Bind(tag = tag, overrides = overrides, binding = instance(creator()))
 
 /**
  * Attaches a binding to the DI container

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/DIBuilder.kt
@@ -1,6 +1,7 @@
 package org.kodein.di
 
 import org.kodein.di.bindings.*
+import org.kodein.di.internal.DIBuilderImpl
 import org.kodein.type.TypeToken
 import org.kodein.type.generic
 
@@ -58,7 +59,7 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindFactory(tag: 
  * @param T The type of the instance.
  * @param instance The object that will always be returned.
  */
-public inline fun <reified T: Any> DI.Builder.bindInstance(tag: Any? = null, overrides: Boolean? = null, creator: () -> T): Unit = Bind(tag, overrides, instance(creator()))
+public inline fun <reified T: Any> DI.Builder.bindInstance(instance: T): Unit = Bind(binding = instance(instance))
 
 /**
  * Binds a constant provider: will always return the given instance.

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
@@ -16,7 +16,7 @@ import org.kodein.type.generic
  * @return A set binding ready to be bound.
  */
 @Suppress("RemoveExplicitTypeArguments")
-//@Deprecated("bind() from has been deprecated", replaceWith = ReplaceWith("bindSet()"))
+@Deprecated("'bind() from ...' has been deprecated", replaceWith = ReplaceWith("bindSet<T>()"))
 public inline fun <reified T: Any> DI.Builder.setBinding(): SetBinding<Any, T> = SetBinding(TypeToken.Any, generic<T>(), erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>)
 
 /**
@@ -29,7 +29,7 @@ public inline fun <reified T: Any> DI.Builder.setBinding(): SetBinding<Any, T> =
  * @return A set binding ready to be bound.
  */
 @Suppress("RemoveExplicitTypeArguments")
-//@Deprecated("", replaceWith = ReplaceWith("bindArgSet()"))
+@Deprecated("'bind() from ...' has been deprecated", replaceWith = ReplaceWith("bindArgSet<A, T>()"))
 public inline fun <reified A : Any, reified T: Any> DI.Builder.argSetBinding(): ArgSetBinding<Any, A, T> = ArgSetBinding(TypeToken.Any, generic<A>(), generic<T>(), erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>)
 
 /**

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
@@ -19,6 +19,7 @@ import org.kodein.type.generic
  * @return A set binding ready to be bound.
  */
 @Suppress("RemoveExplicitTypeArguments")
+//@Deprecated("bind() from has been deprecated", replaceWith = ReplaceWith("bindSet()"))
 public inline fun <reified T: Any> DI.Builder.setBinding(): SetBinding<Any, T> = SetBinding(TypeToken.Any, generic<T>(), erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>)
 
 /**
@@ -31,7 +32,31 @@ public inline fun <reified T: Any> DI.Builder.setBinding(): SetBinding<Any, T> =
  * @return A set binding ready to be bound.
  */
 @Suppress("RemoveExplicitTypeArguments")
+//@Deprecated("", replaceWith = ReplaceWith("bindArgSet()"))
 public inline fun <reified A : Any, reified T: Any> DI.Builder.argSetBinding(): ArgSetBinding<Any, A, T> = ArgSetBinding(TypeToken.Any, generic<A>(), generic<T>(), erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>)
+
+/**
+ * Creates a set: multiple bindings can be added in this set.
+ *
+ * T generics will be erased!
+ *
+ * @param T The created type.
+ * @return A set binding ready to be bound.
+ */
+@Suppress("RemoveExplicitTypeArguments")
+public inline fun <reified T: Any> DI.Builder.bindSet(tag: Any? = null, overrides: Boolean? = null): Unit = Bind(tag = tag, overrides = overrides, binding = SetBinding(TypeToken.Any, generic<T>(), erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>))
+
+/**
+ * Creates a set: multiple bindings can be added in this set.
+ *
+ * T generics will be erased!
+ *
+ * @param A The argument type.
+ * @param T The created type.
+ * @return A set binding ready to be bound.
+ */
+@Suppress("RemoveExplicitTypeArguments")
+public inline fun <reified A : Any, reified T: Any> DI.Builder.bindArgSet(tag: Any? = null, overrides: Boolean? = null): Unit = Bind(tag = tag, overrides = overrides, binding = ArgSetBinding(TypeToken.Any, generic<A>(), generic<T>(), erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>))
 
 /**
  * Defines that the binding will be saved in a set binding.

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
@@ -2,10 +2,7 @@
 
 package org.kodein.di
 
-import org.kodein.di.bindings.ArgSetBinding
-import org.kodein.di.bindings.InSet
-import org.kodein.di.bindings.SetBinding
-import org.kodein.di.bindings.TypeBinderInSet
+import org.kodein.di.bindings.*
 import org.kodein.type.TypeToken
 import org.kodein.type.erasedComp
 import org.kodein.type.generic
@@ -66,3 +63,12 @@ public inline fun <reified A : Any, reified T: Any> DI.Builder.bindArgSet(tag: A
  * @param T The type of the binding.
  */
 public inline fun <reified T: Any> DI.Builder.TypeBinder<T>.inSet(): TypeBinderInSet<T, Set<T>> = InSet(erasedComp(Set::class, generic<T>()) as TypeToken<Set<T>>)
+
+/**
+ * Defines that the binding will be saved in a set binding.
+ *
+ * T generics will be erased!
+ *
+ * @param T The type of the binding.
+ */
+public inline fun <reified T: Any> DI.Builder.inSet(creator: () -> DIBinding<*, *, T>): Unit = Bind(generic<T>()).inSet() with creator()

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/SetBindings.kt
@@ -71,4 +71,4 @@ public inline fun <reified T: Any> DI.Builder.TypeBinder<T>.inSet(): TypeBinderI
  *
  * @param T The type of the binding.
  */
-public inline fun <reified T: Any> DI.Builder.inSet(creator: () -> DIBinding<*, *, T>): Unit = Bind(generic<T>()).inSet() with creator()
+public inline fun <reified T: Any> DI.Builder.inSet(tag: Any? = null, overrides: Boolean? = null, creator: () -> DIBinding<*, *, T>): Unit = BindSet(tag = tag, overrides = overrides, creator())

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/bindings/standardBindings.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/bindings/standardBindings.kt
@@ -196,6 +196,6 @@ public class InstanceBinding<T: Any>(override val createdType: TypeToken<out T>,
      */
     override fun getFactory(key: DI.Key<Any, Unit, T>, di: BindingDI<Any>): (Unit) -> T = { _ -> this.instance }
 
-    override val description: String get() = "${factoryName()} ( ${createdType.simpleDispString()} ) "
-    override val fullDescription: String get() = "${factoryFullName()} ( ${createdType.qualifiedDispString()} ) "
+    override val description: String get() = "${factoryName()} ( ${createdType.simpleDispString()} )"
+    override val fullDescription: String get() = "${factoryFullName()} ( ${createdType.qualifiedDispString()} )"
 }

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/internal/DIBuilderImpl.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/internal/DIBuilderImpl.kt
@@ -42,9 +42,6 @@ internal open class DIBuilderImpl internal constructor(
 
     @Suppress("FunctionName")
     override fun <T : Any> Bind(tag: Any?, overrides: Boolean?, binding: DIBinding<*, *, T>) {
-        if (binding.createdType == TypeToken.Unit) {
-            throw IllegalArgumentException("Using `bind { [BINDING] }` with a *Unit* ${binding.factoryName()} is most likely an error. If you are sure you want to bind the Unit type, please use `bind<Unit>() with ${binding.factoryName()}`.")
-        }
         containerBuilder.bind(
             key = DI.Key(binding.contextType, binding.argType, binding.createdType, tag = tag),
             binding = binding,

--- a/kodein-di/src/commonMain/kotlin/org/kodein/di/internal/DIBuilderImpl.kt
+++ b/kodein-di/src/commonMain/kotlin/org/kodein/di/internal/DIBuilderImpl.kt
@@ -34,15 +34,14 @@ internal open class DIBuilderImpl internal constructor(
 
     inner class ConstantBinder internal constructor(private val _tag: Any, private val _overrides: Boolean?) : DI.Builder.ConstantBinder {
         @Suppress("FunctionName")
-        override fun <T: Any> With(valueType: TypeToken<out T>, value: T) = Bind(tag = _tag, overrides = _overrides) { InstanceBinding(valueType, value) }
+        override fun <T: Any> With(valueType: TypeToken<out T>, value: T) = Bind(tag = _tag, overrides = _overrides, binding = InstanceBinding(valueType, value))
     }
 
     @Suppress("FunctionName")
     override fun <T : Any> Bind(type: TypeToken<out T>, tag: Any?, overrides: Boolean?) = TypeBinder(type, tag, overrides)
 
     @Suppress("FunctionName")
-    override fun <T : Any> Bind(tag: Any?, overrides: Boolean?, createBinding: () -> DIBinding<*, *, T>) {
-        val binding = createBinding()
+    override fun <T : Any> Bind(tag: Any?, overrides: Boolean?, binding: DIBinding<*, *, T>) {
         if (binding.createdType == TypeToken.Unit) {
             throw IllegalArgumentException("Using `bind { [BINDING] }` with a *Unit* ${binding.factoryName()} is most likely an error. If you are sure you want to bind the Unit type, please use `bind<Unit>() with ${binding.factoryName()}`.")
         }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_00_Factory.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_00_Factory.kt
@@ -10,7 +10,7 @@ class Tests_00_Factory {
     @Test
     fun test_00_FactoryBindingGetFactory() {
         val di = DI {
-            bind() from factory { name: String -> Person(name) }
+            bind { factory { name: String -> Person(name) } }
         }
 
         val p1: (String) -> Person by di.factory()
@@ -109,7 +109,99 @@ class Tests_00_Factory {
     }
 
     @Test
-    fun test_07_FactoryDirectBindingGetFactory() {
+    fun test_07_DirectFactoryBindingGetFactory() {
+        val di = DI {
+            bind { factory { name: String -> Person(name) } }
+        }
+
+        val p1: (String) -> Person by di.factory()
+        val p2: (String) -> Person by di.factory()
+
+        assertNotSame(p1("Salomon"), p2("Salomon"))
+    }
+
+    @Test
+    fun test_08_DirectFactoryBindingGetProvider() {
+
+        val di = DI { bind { factory { name: String -> Person(name) } } }
+
+        val p: () -> Person by di.provider(arg = "Salomon")
+        val dp: () -> Person = di.direct.provider(arg = "Salomon")
+
+        assertAllEqual("Salomon", p().name, dp().name)
+
+        val fp: () -> Person by di.provider(fArg = { "Salomon" })
+        val dfp: () -> Person = di.direct.provider(fArg = { "Salomon" })
+
+        assertAllEqual("Salomon", fp().name, dfp().name)
+    }
+
+    @Test
+    fun test_09_DirectFactoryBindingGetInstance() {
+
+        val di = DI { bind { factory { name: String -> Person(name) } } }
+
+        val p: Person by di.instance(arg = "Salomon")
+
+        assertEquals("Salomon", p.name)
+
+        val fp: Person by di.instance(fArg = { "Salomon" })
+
+        assertEquals("Salomon", fp.name)
+    }
+
+    @Test
+    fun test_10_DirectGenericFactoryBindingGetInstance() {
+
+        val di = DI { bind { factory { l: List<*> -> Person(l.first().toString()) } } }
+
+        val p: Person by di.instance(arg = listOf("Salomon", "BRYS"))
+
+        assertEquals("Salomon", p.name)
+    }
+
+    @Test
+    fun test_11_DirectFactoryBindingTwoItfGetInstance() {
+
+        val di = DI {
+            bind { factory { p: IName -> Person(p.firstName) } }
+            bind { factory { p: IFullName -> Person(p.firstName + " " + p.lastName) } }
+        }
+
+        val p: Person by di.instance(arg = FullInfos("Salomon", "BRYS", 30))
+
+        assertFailsWith<DI.NotFoundException> { p.name }
+    }
+
+    @Test
+    fun test_12_DirectFactoryBindingLambdaArgument() {
+        val di = DI {
+            bind { factory { f: () -> Unit -> f } }
+        }
+
+        var passed = false
+        val f = { passed = true }
+
+        val run: () -> Unit by di.instance(arg = f)
+        run.invoke()
+
+        assertTrue(passed)
+    }
+
+    /* TODO enable super types for native platforms
+    @Test
+    fun test_13_DirectBindingStarFactory() {
+        val di = DI {
+            bind() from factory { cls: KClass<*> -> FakeLoggerImpl(cls) }
+        }
+
+        val logger: FakeLogger by di.instance(arg = AwareTest::class)
+        assertEquals(AwareTest::class, logger.cls)
+    }
+    */
+
+    @Test
+    fun test_14_SimpleFactoryBindingGetFactory() {
         val di = DI {
             bindFactory { name: String -> Person(name) }
         }
@@ -121,7 +213,7 @@ class Tests_00_Factory {
     }
 
     @Test
-    fun test_08_BindFactoryGetProvider() {
+    fun test_15_SimpleFactoryBindingFactoryGetProvider() {
 
         val di = DI { bindFactory { name: String -> Person(name) } }
 
@@ -137,7 +229,7 @@ class Tests_00_Factory {
     }
 
     @Test
-    fun test_09_BindFactoryGetInstance() {
+    fun test_16_SimpleFactoryBindingFactoryGetInstance() {
 
         val di = DI { bindFactory { name: String -> Person(name) } }
 
@@ -151,7 +243,7 @@ class Tests_00_Factory {
     }
 
     @Test
-    fun test_10_BindGenericFactoryGetInstance() {
+    fun test_17_SimpleFactoryBindingGenericFactoryGetInstance() {
 
         val di = DI { bindFactory { l: List<*> -> Person(l.first().toString()) } }
 
@@ -161,7 +253,7 @@ class Tests_00_Factory {
     }
 
     @Test
-    fun test_11_BindTwoItfFactoryGetInstance() {
+    fun test_18_SimpleFactoryBindingTwoItfFactoryGetInstance() {
 
         val di = DI {
             bindFactory { p: IName -> Person(p.firstName) }
@@ -174,7 +266,7 @@ class Tests_00_Factory {
     }
 
     @Test
-    fun test_12_BindFactoryLambdaArgument() {
+    fun test_19_SimpleFactoryBindingFactoryLambdaArgument() {
         val di = DI {
             bindFactory { f: () -> Unit -> f }
         }
@@ -189,18 +281,10 @@ class Tests_00_Factory {
     }
 
     /* TODO enable super types for native platforms
-    interface FakeLogger { val cls: KClass<*> }
-
-    class FakeLoggerImpl(override val cls: KClass<*>) : FakeLogger
-
-    class AwareTest(override val di: DI) : DIAware {
-        val logger: FakeLogger by instance(arg = this::class)
-    }
-
     @Test
-    fun test_06_StarFactory() {
+    fun test_20_SimpleFactoryBindingStarFactory() {
         val di = DI {
-            bind() from factory { cls: KClass<*> -> FakeLoggerImpl(cls) }
+            bindFactory { cls: KClass<*> -> FakeLoggerImpl(cls) }
         }
 
         val logger: FakeLogger by di.instance(arg = AwareTest::class)

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_01_Provider.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_01_Provider.kt
@@ -28,4 +28,27 @@ class Tests_01_Provider {
         assertNotSame(p1(), p2())
     }
 
+
+    @Test
+    fun test_03_ProviderDirectBindingGetInstance() {
+
+        val di = DI { bindProvider { Person() } }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance()
+
+        assertNotSame(p1, p2)
+    }
+
+    @Test
+    fun test_04_ProviderDirectBindingGetProvider() {
+
+        val di = DI { bindProvider { Person() } }
+
+        val p1 by di.provider<Person>()
+        val p2 by di.provider<Person>()
+
+        assertNotSame(p1(), p2())
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_01_Provider.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_01_Provider.kt
@@ -30,7 +30,29 @@ class Tests_01_Provider {
 
 
     @Test
-    fun test_03_ProviderDirectBindingGetInstance() {
+    fun test_03_DirectProviderBindingGetInstance() {
+
+        val di = DI { bind { provider { Person() } } }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance()
+
+        assertNotSame(p1, p2)
+    }
+
+    @Test
+    fun test_04_DirectProviderBindingGetProvider() {
+
+        val di = DI { bind { provider { Person() } } }
+
+        val p1 by di.provider<Person>()
+        val p2 by di.provider<Person>()
+
+        assertNotSame(p1(), p2())
+    }
+
+    @Test
+    fun test_05_SimpleProviderBindingGetInstance() {
 
         val di = DI { bindProvider { Person() } }
 
@@ -41,7 +63,7 @@ class Tests_01_Provider {
     }
 
     @Test
-    fun test_04_ProviderDirectBindingGetProvider() {
+    fun test_06_SimpleProviderBindingGetProvider() {
 
         val di = DI { bindProvider { Person() } }
 

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_02_Singleton.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_02_Singleton.kt
@@ -42,7 +42,29 @@ class Tests_02_Singleton {
     }
 
     @Test
-    fun test_03_SingletonDirectBindingGetInstance() {
+    fun test_03_DirectSingletonBindingGetInstance() {
+
+        val di = DI { bind { singleton { Person() } } }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance()
+
+        assertSame(p1, p2)
+    }
+
+    @Test
+    fun test_04_DirectSingletonBindingGetProvider() {
+
+        val di = DI { bind { singleton { Person() } } }
+
+        val p1: () -> Person by di.provider()
+        val p2: () -> Person by di.provider()
+
+        assertSame(p1(), p2())
+    }
+
+    @Test
+    fun test_05_SimpleSingletonBindingGetInstance() {
 
         val di = DI { bindSingleton { Person() } }
 
@@ -53,7 +75,7 @@ class Tests_02_Singleton {
     }
 
     @Test
-    fun test_04_SingletonDirectBindingGetProvider() {
+    fun test_06_SimpleSingletonBindingGetProvider() {
 
         val di = DI { bindSingleton { Person() } }
 

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_02_Singleton.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_02_Singleton.kt
@@ -41,4 +41,25 @@ class Tests_02_Singleton {
         assertSame(p1, p2)
     }
 
+    @Test
+    fun test_03_SingletonDirectBindingGetInstance() {
+
+        val di = DI { bindSingleton { Person() } }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance()
+
+        assertSame(p1, p2)
+    }
+
+    @Test
+    fun test_04_SingletonDirectBindingGetProvider() {
+
+        val di = DI { bindSingleton { Person() } }
+
+        val p1: () -> Person by di.provider()
+        val p2: () -> Person by di.provider()
+
+        assertSame(p1(), p2())
+    }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
@@ -63,7 +63,7 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bindInstance(p) }
+        val di = DI { bindInstance { p } }
 
         val p1: Person by di.instance()
         val p2: Person by di.instance()
@@ -76,7 +76,7 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bindInstance(p) }
+        val di = DI { bindInstance { p } }
 
         val p1: () -> Person by di.provider()
         val p2: () -> Person by di.provider()

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
@@ -31,4 +31,31 @@ class Tests_03_Instance {
         assertSame(p1(), p)
         assertSame(p2(), p)
     }
+
+
+    @Test fun test_03_InstanceDirectBindingGetInstance() {
+
+        val p = Person()
+
+        val di = DI { bindInstance(p) }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance()
+
+        assertSame(p1, p)
+        assertSame(p2, p)
+    }
+
+    @Test fun test_04_InstanceDirectBindingGetProvider() {
+
+        val p = Person()
+
+        val di = DI { bindInstance(p) }
+
+        val p1: () -> Person by di.provider()
+        val p2: () -> Person by di.provider()
+
+        assertSame(p1(), p)
+        assertSame(p2(), p)
+    }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
@@ -63,7 +63,7 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bindInstance { p } }
+        val di = DI { bindInstance(p) }
 
         val p1: Person by di.instance()
         val p2: Person by di.instance()
@@ -76,7 +76,7 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bindInstance { p } }
+        val di = DI { bindInstance(p) }
 
         val p1: () -> Person by di.provider()
         val p2: () -> Person by di.provider()

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
@@ -63,7 +63,7 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bindInstance(p) }
+        val di = DI { bindInstance { p } }
 
         val p1: Person by di.instance()
         val p2: Person by di.instance()
@@ -76,12 +76,30 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bindInstance(p) }
+        val di = DI { bindInstance { p } }
 
         val p1: () -> Person by di.provider()
         val p2: () -> Person by di.provider()
 
         assertSame(p1(), p)
         assertSame(p2(), p)
+    }
+
+    fun unit(@Suppress("UNUSED_PARAMETER") i: Int = 42) {}
+
+    @Test fun test_07_BindWithUnit() {
+        val di = DI.direct {
+            bind<Unit>() with instance(unit())
+        }
+
+        assertSame(Unit, di.instance())
+    }
+
+    @Test fun test_08_DirectBindUnit() {
+        val di = DI.direct {
+            bind { instance(unit()) }
+        }
+
+        assertSame(Unit, di.instance())
     }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_03_Instance.kt
@@ -10,7 +10,7 @@ class Tests_03_Instance {
 
         val p = Person()
 
-        val di = DI { bind() from instance(p) }
+        val di = DI { bind<Person>() with instance(p) }
 
         val p1: Person by di.instance()
         val p2: Person by di.instance()
@@ -33,7 +33,33 @@ class Tests_03_Instance {
     }
 
 
-    @Test fun test_03_InstanceDirectBindingGetInstance() {
+    @Test fun test_03_DirectInstanceBindingGetInstance() {
+
+        val p = Person()
+
+        val di = DI { bind { instance(p) } }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance()
+
+        assertSame(p1, p)
+        assertSame(p2, p)
+    }
+
+    @Test fun test_04_DirectInstanceBindingGetProvider() {
+
+        val p = Person()
+
+        val di = DI { bind { instance(p) } }
+
+        val p1: () -> Person by di.provider()
+        val p2: () -> Person by di.provider()
+
+        assertSame(p1(), p)
+        assertSame(p2(), p)
+    }
+
+    @Test fun test_05_SimpleInstanceBindingGetInstance() {
 
         val p = Person()
 
@@ -46,7 +72,7 @@ class Tests_03_Instance {
         assertSame(p2, p)
     }
 
-    @Test fun test_04_InstanceDirectBindingGetProvider() {
+    @Test fun test_06_SimpleInstanceBindingGetProvider() {
 
         val p = Person()
 

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_04_NullBinding.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_04_NullBinding.kt
@@ -71,4 +71,40 @@ class Tests_04_NullBinding {
 
         assertAllEqual("Salomon BRYS", f!!.invoke("Salomon"), df!!.invoke("Salomon"), p!!(), dp!!(), fp!!(), dfp!!(), i!!, di!!, fi!!)
     }
+
+    @Test fun test_04_NonNullDirectBindingProviderAndInstance() {
+
+        val kodein = DI {
+            bind { provider { "Salomon" } }
+        }
+
+        val i: String? by kodein.instanceOrNull()
+        val di: String? = kodein.direct.instanceOrNull()
+        val p: (() -> String)? by kodein.providerOrNull()
+        val dp: (() -> String)? = kodein.direct.providerOrNull()
+
+        assertAllNotNull(i, di, p, dp)
+        assertAllEqual("Salomon", i!!, di!!, p!!(), dp!!())
+    }
+
+    @Test fun test_05_NonNullDirectBindingGetFactory() {
+
+        val kodein = DI {
+            bind { factory { name: String -> "$name BRYS" } }
+        }
+
+        val f: ((String) -> String)? by kodein.factoryOrNull()
+        val df: ((String) -> String)? = kodein.direct.factoryOrNull()
+        val p: (() -> String)? by kodein.providerOrNull(arg = "Salomon")
+        val dp: (() -> String)? = kodein.direct.providerOrNull(arg = "Salomon")
+        val fp: (() -> String)? by kodein.providerOrNull(fArg = { "Salomon" })
+        val dfp: (() -> String)? = kodein.direct.providerOrNull(fArg = { "Salomon" })
+        val i: String? by kodein.instanceOrNull(arg = "Salomon")
+        val di: String? = kodein.direct.instanceOrNull(arg = "Salomon")
+        val fi: String? by kodein.instanceOrNull(fArg = { "Salomon" })
+
+        assertAllNotNull(f, df, p, dp, fp, dfp, i, di, fi)
+
+        assertAllEqual("Salomon BRYS", f!!.invoke("Salomon"), df!!.invoke("Salomon"), p!!(), dp!!(), fp!!(), dfp!!(), i!!, di!!, fi!!)
+    }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_05_Named.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_05_Named.kt
@@ -92,4 +92,90 @@ class Tests_05_Named {
         assertSame(named(), p3())
     }
 
+    @Test fun test_06_NamedProviderDirectBindingGetInstance() {
+        val di = DI {
+            bind { provider { Person() } }
+            bind(tag = "named") { provider { Person("Salomon") } }
+        }
+
+        val p1: Person by di.instance()
+        val p2: Person by di.instance(tag = "named")
+
+        assertNull(p1.name)
+        assertEquals("Salomon", p2.name)
+    }
+
+    @Test fun test_07_NamedProviderDirectBindingGetProvider() {
+        val di = DI {
+            bind { provider { Person() } }
+            bind(tag = "named") { provider { Person("Salomon") } }
+        }
+
+        val p1: () -> Person by di.provider()
+        val p2: () -> Person by di.provider(tag = "named")
+
+        assertNull(p1().name)
+        assertEquals("Salomon", p2().name)
+    }
+
+    @Test fun test_08_NamedSingletonDirectBindingGetInstance() {
+        val di = DI {
+            bind { singleton { Person() } }
+            bind(tag = "named") { singleton { Person("Salomon") } }
+        }
+
+        val p1: Person by di.instance(tag = "named")
+        val named: Person by di.named.instance()
+
+        assertEquals("Salomon", p1.name)
+        assertSame(p1, named)
+    }
+
+    @Test fun test_09_NamedSingletonDirectBindingGetProvider() {
+        val di = DI {
+            bind { singleton { Person() } }
+            bind(tag = "named") { singleton { Person("Salomon") } }
+        }
+
+        val p1: () -> Person by di.provider(tag = "named")
+        val named: () -> Person by di.named.provider()
+
+        assertEquals("Salomon", p1().name)
+        assertSame(p1(), named())
+    }
+
+    @Test fun test_10_NamedInstanceDirectBindingGetInstance() {
+
+        val di = DI {
+            bind { instance(Person()) }
+            bind(tag = "named") { instance(Person("Salomon")) }
+        }
+
+        val p1: Person by di.instance()
+        val named: Person by di.named.instance()
+        val p3: Person by di.instance(tag = "named")
+
+        assertNull(p1.name)
+        assertEquals("Salomon", named.name)
+        assertNotSame(p1, named)
+        assertSame(named, p3)
+    }
+
+    @Test fun test_11_NamedInstanceDirectBindingGetProvider() {
+
+        val di = DI {
+            bind { instance(Person()) }
+            bind(tag = "named") { instance(Person("Salomon")) }
+        }
+
+        val p1: () -> Person by di.provider()
+        val named: () -> Person by di.named.provider()
+        val p3: () -> Person by di.provider(tag = "named")
+
+        assertNull(p1().name)
+        assertEquals("Salomon", named().name)
+        assertNotSame(p1(), named())
+        assertSame(named(), p3())
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_06_Constant.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_06_Constant.kt
@@ -51,4 +51,45 @@ class Tests_06_Constant {
     }
 
 
+    @Test
+    fun test_03_SimpleConstantBindingGetInstance() {
+
+        val di = DI {
+            bindConstant(tag = "answer") { 42 }
+        }
+
+        val c: Int by di.instance(tag = "answer")
+        val answer: Int by di.constant()
+
+        assertEquals(42, c)
+        assertEquals(42, answer)
+    }
+
+    @Test
+    fun test_04_SimpleConstantBindingGetProvider() {
+
+        val di = DI {
+            bindConstant(tag = "answer") { 42 }
+        }
+
+        val c: () -> Int by di.provider(tag = "answer")
+
+        assertEquals(42, c())
+    }
+
+    @Test
+    fun test_05_SimpleConstantBindingGetPolymorphic() {
+
+        val di = DI {
+            bindConstant<IPerson>(tag = "salomon") { Person("Salomon") }
+        }
+
+        val p: IPerson by di.instance(tag = "salomon")
+        val salomon: IPerson by di.constant()
+
+        assertEquals(Person("Salomon"), p)
+        assertEquals(Person("Salomon"), salomon)
+    }
+
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_07_Error.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_07_Error.kt
@@ -42,10 +42,10 @@ Dependency recursion:
     @Test fun test_01_DependencyLoopInClass() {
 
         val di = DI {
-            bind() from provider { Recurs0(instance()) }
-            bind() from provider { RecursA(instance()) }
-            bind() from provider { RecursB(instance(tag = "yay")) }
-            bind(tag = "yay") from provider { RecursC(instance()) }
+            bind { provider { Recurs0(instance()) } }
+            bind { provider { RecursA(instance()) } }
+            bind { provider { RecursB(instance(tag = "yay")) } }
+            bind(tag = "yay") { provider { RecursC(instance()) } }
         }
 
         assertFailsWith<DI.DependencyLoopException> {
@@ -140,16 +140,16 @@ Dependency recursion:
 
         val di = DI.direct {
             assertFailsWith<IllegalArgumentException> {
-                bind() from factory { i: Int -> unit(i) }
+                bind { factory { i: Int -> unit(i) } }
             }
             assertFailsWith<IllegalArgumentException> {
-                bind() from provider { unit() }
+                bind { provider { unit() } }
             }
             assertFailsWith<IllegalArgumentException> {
-                bind() from instance(Unit)
+                bind { instance(Unit) }
             }
             assertFailsWith<IllegalArgumentException> {
-                bind() from singleton { unit() }
+                bind { singleton { unit() } }
             }
 
             bind<Unit>() with instance(unit())

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_07_Error.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_07_Error.kt
@@ -21,10 +21,10 @@ class Tests_07_Error {
 
         assertEquals("""
 Dependency recursion:
-     bind<A>()
-    ╔╩>bind<B>()
-    ║  ╚>bind<C>()
-    ║    ╚>bind<A>()
+     bind<A>
+    ╔╩>bind<B>
+    ║  ╚>bind<C>
+    ║    ╚>bind<A>
     ╚══════╝
         """.trim(), ex.message?.trim()
         )
@@ -73,7 +73,7 @@ Dependency recursion:
 
         val di = DI.direct {}
 
-        assertEquals("No binding found for bind<Person>() with ? { ? }", assertFailsWith<DI.NotFoundException> { di.instance<Person>() }.message)
+        assertEquals("No binding found for bind<Person> { ? { ? } }", assertFailsWith<DI.NotFoundException> { di.instance<Person>() }.message)
 
         assertFailsWith<DI.NotFoundException> { di.instance<FullName>() }
 
@@ -87,7 +87,7 @@ Dependency recursion:
 
         val di = DI.direct { fullContainerTreeOnError = true }
 
-        assertEquals("No binding found for bind<Person>() with ? { ? }\nRegistered in this DI container:\n", assertFailsWith<DI.NotFoundException> { di.instance<Person>() }.message)
+        assertEquals("No binding found for bind<Person> { ? { ? } }\nRegistered in this DI container:\n", assertFailsWith<DI.NotFoundException> { di.instance<Person>() }.message)
 
         assertFailsWith<DI.NotFoundException> { di.instance<FullName>() }
 
@@ -134,27 +134,77 @@ Dependency recursion:
     }
 
     @Test
-    fun test_08_BindFromUnit() {
+    fun test_08_SimpleBinding_DependencyLoop() {
 
-        fun unit(@Suppress("UNUSED_PARAMETER") i: Int = 42) {}
-
-        val di = DI.direct {
-            assertFailsWith<IllegalArgumentException> {
-                bind { factory { i: Int -> unit(i) } }
-            }
-            assertFailsWith<IllegalArgumentException> {
-                bind { provider { unit() } }
-            }
-            assertFailsWith<IllegalArgumentException> {
-                bind { instance(Unit) }
-            }
-            assertFailsWith<IllegalArgumentException> {
-                bind { singleton { unit() } }
-            }
-
-            bind<Unit>() with instance(unit())
+        val di = DI {
+            bindSingleton { A(instance()) } 
+            bindSingleton { B(instance()) } 
+            bindSingleton { C(instance()) } 
         }
 
-        assertSame(Unit, di.instance())
+        val ex = assertFailsWith<DI.DependencyLoopException> {
+            di.direct.instance<A>()
+        }
+
+        assertEquals("""
+Dependency recursion:
+     bind<A>
+    ╔╩>bind<B>
+    ║  ╚>bind<C>
+    ║    ╚>bind<A>
+    ╚══════╝
+        """.trim(), ex.message?.trim()
+        )
+    }
+
+    @Test
+    fun test_09_SimpleBinding_NoDependencyLoop() {
+
+        val di = DI {
+            bindSingleton { A(instance()) }
+            bindSingleton(tag = "root") { A(null) }
+            bindSingleton { B(instance()) }
+            bindSingleton { C(instance(tag = "root")) }
+        }
+
+        val a by di.instance<A>()
+        assertNotNull(a.b?.c?.a)
+    }
+
+    @Test
+    fun test_10_SimpleBinding_NameNotFound() {
+
+        val di = DI.direct {
+            bindProvider { Person() }
+            bindProvider(tag = "named") { Person("Salomon") }
+        }
+
+        assertFailsWith<DI.NotFoundException> {
+            di.instance<Person>(tag = "schtroumpf")
+        }
+    }
+
+    @Test
+    fun test_11_SimpleBinding_FactoryIsNotProvider() {
+
+        val di = DI.direct {
+            bindFactory { name: String -> Person(name) }
+        }
+
+        assertFailsWith<DI.NotFoundException> {
+            di.provider<Person>()
+        }
+    }
+
+    @Test
+    fun test_12_SimpleBinding_ProviderIsNotFactory() {
+
+        val di = DI.direct {
+            bindProvider { Person() }
+        }
+
+        assertFailsWith<DI.NotFoundException> {
+            di.factory<Int, Person>()
+        }
     }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_09_InClass.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_09_InClass.kt
@@ -33,4 +33,20 @@ class Tests_09_InClass {
         assertEquals("Laila", container.factory("Laila").name)
     }
 
+    @Test
+    fun test_01_SimpleBinding_Class() {
+        val di = DI {
+            bindProvider { Person() }
+            bindSingleton(tag = "named") { Person("Salomon") }
+            bindFactory(tag = "factory") { name: String -> Person(name) }
+        }
+
+        val container = PersonContainer(di)
+        assertNotSame(container.newPerson(), container.newPerson())
+        assertEquals("Salomon", container.salomon.name)
+        assertSame(container.salomon, container.salomon)
+        assertNotSame(container.factory("Laila"), container.factory("Laila"))
+        assertEquals("Laila", container.factory("Laila").name)
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_10_Module.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_10_Module.kt
@@ -97,4 +97,76 @@ class Tests_10_Module {
         assertEquals(salomon, container3.direct.instance())
         assertSame(container1.direct.instance<String>(), container2.direct.instance(), container3.direct.instance())
     }
+
+    @Test
+    fun test_03_SimpleBinding_ModuleImport() {
+
+        val personModule = DI.Module("test") {
+            bindProvider { Person() }
+            bindSingleton(tag = "named") { Person("Salomon") }
+            bindFactory(tag = "factory") { name: String -> Person(name) }
+        }
+
+        val di = DI {
+            import(personModule)
+        }
+
+        val container = PersonContainer(di)
+        assertNotSame(container.newPerson(), container.newPerson())
+        assertEquals("Salomon", container.salomon.name)
+        assertSame(container.salomon, container.salomon)
+        assertNotSame(container.factory("Laila"), container.factory("Laila"))
+        assertEquals("Laila", container.factory("Laila").name)
+
+        val kodein2 = DI {
+            import(personModule)
+        }
+
+        assertSame(di.direct.instance<Person>(tag = "named"), di.direct.instance(tag = "named"))
+        assertSame(kodein2.direct.instance<Person>(tag = "named"), kodein2.direct.instance(tag = "named"))
+        assertNotSame(di.direct.instance<Person>(tag = "named"), kodein2.direct.instance(tag = "named"))
+    }
+
+    @Test
+    fun test_04_SimpleBinding_ModuleOnce() {
+
+        val module = DI.Module("test") {
+            bindInstance { "Salomon" }
+        }
+
+        val di = DI {
+            importOnce(module)
+            importOnce(module)
+        }
+
+        assertEquals("Salomon", di.direct.instance())
+    }
+
+    @Test
+    fun test_05_SimpleBinding_ModuleOverExtend() {
+        val salomon = "Salomon"
+        val module = DI.Module("test") {
+            bindInstance { salomon }
+        }
+
+        val container1 = DI {
+            importOnce(module)
+        }
+
+        val container2 = DI {
+            extend(container1)
+            importOnce(module)
+        }
+
+        val container3 = DI {
+            extend(container2)
+            importOnce(module)
+        }
+
+        assertEquals(salomon, container1.direct.instance())
+        assertEquals(salomon, container2.direct.instance())
+        assertEquals(salomon, container3.direct.instance())
+        assertSame(container1.direct.instance<String>(), container2.direct.instance(), container3.direct.instance())
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_11_Extend.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_11_Extend.kt
@@ -136,20 +136,171 @@ class Tests_11_Extend {
     }
 
     @Test
-    fun test_06_DIExtendCopyAllBut() {
+    fun test_06_SimpleBinding_DIExtendCopyAllBut() {
         data class Foo(val name: String)
         data class Bar(val foo: Foo)
 
         val root = DI.direct {
-            bind<Foo>() with provider { Foo("rootFoo") }
-            bind<Bar>() with singleton { Bar(instance()) }
+            bindProvider { Foo("rootFoo") }
+            bindSingleton { Bar(instance()) }
         }
 
         val sub = DI.direct {
             extend(root, allowOverride = true, copy = Copy.allBut {
                 ignore all binding<Bar>()
             })
-            bind<Foo>(overrides = true) with provider { Foo("subFoo") }
+            bindProvider(overrides = true) { Foo("subFoo") }
+        }
+
+        val subBar : Bar = sub.instance()
+        val rootBar : Bar = root.instance()
+
+        assertSame(rootBar, subBar)
+        assertEquals("rootFoo", rootBar.foo.name)
+    }
+
+    @Test
+    fun test_07_SimpleBinding_DIExtend() {
+
+        val parent = DI {
+            bindSingleton(tag = "named") { Person("Salomon") }
+        }
+
+        val child = DI {
+            extend(parent)
+            bindProvider { Person() }
+        }
+
+        assertSame(parent.direct.instance<Person>(tag = "named"), child.direct.instance(tag = "named"))
+        assertNull(parent.direct.instanceOrNull<Person>())
+        assertNotNull(child.direct.instanceOrNull<Person>())
+    }
+
+    @Test
+    fun test_08_SimpleBinding_DIExtendOverride() {
+
+        val parent = DI {
+            bindSingleton { "parent" }
+        }
+
+        val child = DI {
+            extend(parent)
+            bindSingleton(overrides = true) { "child" }
+        }
+
+        assertEquals("parent", parent.direct.instance())
+        assertEquals("child", child.direct.instance())
+    }
+
+    @Test
+    fun test_09_SimpleBinding_DIExtendOverriddenInstance() {
+
+        data class Foo(val name: String)
+        data class Bar(val foo: Foo)
+
+        val root = DI.direct {
+            bindProvider { Foo("rootFoo") }
+            bindProvider { Bar(instance()) }
+        }
+
+        val sub = DI.direct {
+            extend(root, allowOverride = true, copy = Copy.None)
+            bindProvider(overrides = true) { Foo("subFoo") }
+        }
+
+        val subBar : Bar = sub.instance()
+        val rootBar : Bar = root.instance()
+
+        assertEquals("rootFoo", rootBar.foo.name)
+        assertEquals("rootFoo", subBar.foo.name)
+    }
+
+    @Test
+    fun test_10_SimpleBinding_DIExtendOverriddenInstanceCopy() {
+
+        data class Foo(val name: String)
+        data class Bar(val foo: Foo)
+
+        val root = DI.direct {
+            bindProvider { Foo("rootFoo") }
+            bindProvider { Bar(instance()) }
+        }
+
+        val sub = DI.direct {
+            extend(root, allowOverride = true, copy = Copy.All)
+            bindProvider(overrides = true) { Foo("subFoo") }
+        }
+
+        val subBar : Bar = sub.instance()
+        val rootBar : Bar = root.instance()
+
+        assertEquals("rootFoo", rootBar.foo.name)
+        assertEquals("subFoo", subBar.foo.name)
+    }
+
+    @Test
+    fun test_11_SimpleBinding_DIExtendOverriddenSingletonSame() {
+
+        data class Foo(val name: String)
+        data class Bar(val foo: Foo)
+
+        val root = DI.direct {
+            bindProvider { Foo("rootFoo") }
+            bindSingleton { Bar(instance()) }
+        }
+
+        val sub = DI.direct {
+            extend(root, allowOverride = true)
+            bindProvider(overrides = true) { Foo("subFoo") }
+        }
+
+        val subBar : Bar = sub.instance()
+        val rootBar : Bar = root.instance()
+
+        assertSame(rootBar, subBar)
+        assertEquals("rootFoo", rootBar.foo.name)
+    }
+
+    @Test
+    fun test_12_SimpleBinding_DIExtendOverriddenSingletonCopy() {
+        data class Foo(val name: String)
+        data class Bar(val foo: Foo)
+
+        val root = DI.direct {
+            bindProvider { Foo("rootFoo") }
+            bindSingleton { Bar(instance()) }
+        }
+
+        val sub = DI.direct {
+            extend(root, allowOverride = true, copy = Copy {
+                copy all binding<Bar>()
+            })
+            bindProvider(overrides = true) { Foo("subFoo") }
+        }
+
+        val subBar : Bar = sub.instance()
+        val rootBar : Bar = root.instance()
+
+        assertNotSame(rootBar, subBar)
+        assertEquals("rootFoo", rootBar.foo.name)
+        assertEquals("subFoo", subBar.foo.name)
+    }
+
+    @Test
+    fun test_13_SimpleBinding_DIExtendCopyAllBut() {
+        data class Foo(val name: String)
+        data class Bar(val foo: Foo)
+
+        val root = DI.direct {
+            bindProvider { Foo("rootFoo") }
+            bindSingleton { Bar(instance()) }
+        }
+
+        val sub = DI.direct {
+            extend(root, allowOverride = true, copy = Copy.allBut {
+                ignore all binding<Bar>()
+            })
+            bindProvider(overrides = true) { Foo("subFoo") }
         }
 
         val subBar : Bar = sub.instance()

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_12_Trigger.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_12_Trigger.kt
@@ -59,5 +59,41 @@ class Tests_12_Trigger {
         assertTrue(created)
     }
 
+    @Test
+    fun test_02_SimpleBinding_SimpleTrigger() {
+        val di = DI {
+            bindProvider { Person() }
+            bindSingleton(tag = "named") { Person("Salomon") }
+            bindFactory(tag = "factory") { name: String -> Person(name) }
+        }
+
+        val injected = T00(di)
+
+        injected.diTrigger.trigger()
+        assertNotSame(injected.newPerson(), injected.newPerson())
+        assertEquals("Salomon", injected.salomon.name)
+        assertSame(injected.salomon, injected.salomon)
+        assertNotSame(injected.pFactory("Laila"), injected.pFactory("Laila"))
+        assertEquals("Laila", injected.pFactory("Laila").name)
+        assertEquals("provided", injected.pProvider().name)
+        assertNotSame(injected.pProvider(), injected.pProvider())
+        assertEquals("reified", injected.instance.name)
+        assertSame(injected.instance, injected.instance)
+    }
+
+    @Test
+    fun test_03_SimpleBinding_CreatedAtTrigger() {
+        var created = false
+        val di = DI {
+            bindSingleton { created = true; Person() }
+        }
+
+        val container = T01(di)
+
+        assertFalse(created)
+        container.diTrigger.trigger()
+        assertTrue(created)
+    }
+
 
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_13_Scope.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_13_Scope.kt
@@ -139,7 +139,7 @@ class Tests_13_Scope {
         }
 
         val kodein = DI {
-            bind() from scoped(testScope).singleton { Person(context.name) }
+            bind { scoped(testScope).singleton { Person(context.name) } }
         }
 
         val test1 = T05(kodein, "one")
@@ -207,9 +207,9 @@ class Tests_13_Scope {
     @Test
     fun test_08_CircularScopes() {
         val di = DI.direct {
-            bind() from contexted<D>().provider { context.str }
-            bind() from contexted<E>().provider { context.int }
-            bind() from contexted<F>().provider { context.char }
+            bind { contexted<D>().provider { context.str } }
+            bind { contexted<E>().provider { context.int } }
+            bind { contexted<F>().provider { context.char } }
             registerContextTranslator { d: D -> d.e }
             registerContextTranslator { e: E -> e.f }
             registerContextTranslator { f: F -> f.d }
@@ -237,7 +237,7 @@ class Tests_13_Scope {
     @Test
     fun test_09_ContextTranslatorAndReceiver() {
         val di = DI.direct {
-            bind() from contexted<Name>().provider { FullName(context.firstName, "BRYS") }
+            bind { contexted<Name>().provider { FullName(context.firstName, "BRYS") } }
             registerContextFinder { Name("Salomon") }
             registerContextTranslator { name: String -> Name(name) }
         }
@@ -257,14 +257,14 @@ class Tests_13_Scope {
         }
         class CurrentName(var current: Name)
         val di = DI.direct {
-            bind() from scoped(nameScope).singleton { FullName(context.firstName, "BRYS") }
-            bind() from singleton { CurrentName(Name("Salomon")) }
-            registerContextFinder<Name> { instance<CurrentName>().current }
+            bind { scoped(nameScope).singleton { FullName(context.firstName, "BRYS") } }
+            bind { singleton { CurrentName(Name("Salomon")) } }
+            registerContextFinder { instance<CurrentName>().current }
         }
 
-        assertEquals(FullName("Salomon", "BRYS"), di.instance<FullName>())
+        assertEquals(FullName("Salomon", "BRYS"), di.instance())
         di.instance<CurrentName>().current = Name("Laila")
-        assertEquals(FullName("Laila", "BRYS"), di.instance<FullName>())
+        assertEquals(FullName("Laila", "BRYS"), di.instance())
     }
 
 

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_13_Scope.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_13_Scope.kt
@@ -268,4 +268,176 @@ class Tests_13_Scope {
     }
 
 
+    @Test
+    fun test_11_DirectBinding_AnyScopeSingleton() {
+        val registry = StandardScopeRegistry()
+        val myScope = object : Scope<Any?> {
+            override fun getRegistry(context: Any?) = registry
+        }
+        val kodein = DI {
+            bind { scoped(myScope).singleton { Person() } }
+        }
+
+        assertTrue(registry.isEmpty())
+
+        val person: Person by kodein.instance()
+        assertSame(person, kodein.direct.instance())
+
+        assertFalse(registry.isEmpty())
+
+        registry.clear()
+
+        assertTrue(registry.isEmpty())
+
+        assertNotSame(person, kodein.direct.instance())
+    }
+
+    @Test
+    fun test_12_DirectBinding_ScopeSingleton() {
+
+        val registries = mapOf("a" to SingleItemScopeRegistry(), "b" to SingleItemScopeRegistry())
+        val myScope = object : Scope<String> {
+            override fun getRegistry(context: String) = registries[context]!!
+        }
+        val kodein = DI {
+            bind { scoped(myScope).singleton { Person() } }
+        }
+
+        assertTrue(registries["a"]!!.isEmpty())
+
+        val a: Person by kodein.on(context = "a").instance()
+        val b: Person by kodein.on(context = "b").instance()
+        assertNotSame(a, b)
+        assertSame(a, kodein.direct.on(context = "a").instance())
+        assertSame(b, kodein.direct.on(context = "b").instance())
+
+        assertFalse(registries["a"]!!.isEmpty())
+
+        registries.values.forEach { it.clear() }
+
+        assertTrue(registries["a"]!!.isEmpty())
+
+        assertNotSame(a, kodein.direct.on(context = "a").instance())
+        assertNotSame(b, kodein.direct.on(context = "b").instance())
+    }
+
+    @Test
+    fun test_13_DirectBinding_ScopeIgnoredSingleton() {
+
+        val kodein = DI {
+            bind { singleton { Person() } }
+        }
+
+        val a: Person by kodein.on(context = "a").instance()
+        val b: Person by kodein.on(context = "b").instance()
+        assertSame(a, b)
+    }
+
+    @Test
+    fun test_14_DirectBinding_ScopeCloseableSingleton() {
+
+        val myScope = UnboundedScope(SingleItemScopeRegistry())
+
+        val kodein = DI {
+            bind { scoped(myScope).singleton { CloseableData() } }
+        }
+
+        val a: CloseableData by kodein.instance()
+        val b: CloseableData by kodein.instance()
+        assertSame(a, b)
+        assertFalse(a.closed)
+        myScope.registry.clear()
+        val c: CloseableData by kodein.instance()
+
+        assertNotSame(a, c)
+        assertTrue(a.closed)
+        assertFalse(c.closed)
+    }
+
+    @Test
+    fun test_15_DirectBinding_SubScopedSingleton() {
+        data class Session(val id: String)
+        data class Request(val session: Session)
+
+        val sessionScope = object : Scope<Session> {
+            val registries = HashMap<String, ScopeRegistry>()
+            override fun getRegistry(context: Session) = registries.getOrPut(context.id, ::StandardScopeRegistry)
+        }
+
+        val requestScope = object : SubScope<Request, Session>(sessionScope) {
+            override fun getParentContext(context: Request) = context.session
+        }
+
+        val kodein = DI {
+            bind { scoped(requestScope).singleton { CloseableData() } }
+        }
+
+        val session = Session("sid")
+        val request = Request(session)
+
+        val a: CloseableData by kodein.on(request).instance()
+        val b: CloseableData by kodein.on(request).instance()
+        assertSame(a, b)
+        assertFalse(a.closed)
+        sessionScope.getRegistry(session).clear()
+        val c: CloseableData by kodein.on(request).instance()
+
+        assertNotSame(a, c)
+        assertTrue(a.closed)
+        assertFalse(c.closed)
+    }
+
+    @Test
+    fun test_16_DirectBinding_ContextTranslatorScope() {
+        data class Session(val id: String)
+        data class Request(val session: Session)
+
+        val sessionScope = object : Scope<Session> {
+            val registries = HashMap<String, ScopeRegistry>()
+            override fun getRegistry(context: Session) = registries.getOrPut(context.id, ::StandardScopeRegistry)
+        }
+
+        val kodein = DI {
+            bind { scoped(sessionScope).singleton { CloseableData() } }
+            registerContextTranslator { r: Request -> r.session }
+        }
+
+        val session = Session("sid")
+        val request = Request(session)
+
+        val c: CloseableData by kodein.on(request).instance()
+        assertFalse(c.closed)
+        sessionScope.registries[session.id]!!.clear()
+        assertTrue(c.closed)
+    }
+
+    @Test
+    fun test_17_DirectBinding_ContextTranslatorAutoScope() {
+        data class Session(val id: String)
+        data class Request(val session: Session)
+
+        val sessionScope = object : Scope<Session> {
+            val registries = HashMap<String, ScopeRegistry>()
+            override fun getRegistry(context: Session) = registries.getOrPut(context.id, ::StandardScopeRegistry)
+        }
+
+        val session = Session("sid")
+        val request = Request(session)
+
+        val parentDI = DI {
+            bind { scoped(sessionScope).singleton { CloseableData() } }
+            registerContextTranslator { r: Request -> r.session }
+            registerContextFinder { request }
+        }
+
+        val kodein = DI {
+            extend(parentDI)
+        }
+
+        val c: CloseableData by kodein.instance()
+        assertFalse(c.closed)
+        sessionScope.registries[session.id]!!.clear()
+        assertTrue(c.closed)
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_14_Override.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_14_Override.kt
@@ -125,5 +125,45 @@ class Tests_14_Override {
         }
     }
 
+    @Test
+    fun test_09_DirectBindingExplicitOverride() {
+        val di = DI {
+            bind(tag = "name") { instance("Benjamin") }
+            bind(tag = "name", overrides = true) { instance("Salomon") }
+        }
 
+        assertEquals("Salomon", di.direct.instance(tag = "name"))
+    }
+
+    @Test
+    fun test_10_DirectBindingSilentOverride() {
+        val di = DI(allowSilentOverride = true) {
+            bind(tag = "name") { instance("Benjamin") }
+            bind(tag = "name") { instance("Salomon") }
+        }
+
+        assertEquals("Salomon", di.direct.instance(tag = "name"))
+    }
+
+    @Test
+    fun test_11_DirectBindingSilentOverrideNotAllowed() {
+        DI {
+            bind(tag = "name") { instance("Benjamin") }
+
+            assertFailsWith<DI.OverridingException> {
+                bind(tag = "name") { instance("Salomon") }
+            }
+        }
+    }
+
+    @Test
+    fun test_12_DirectBindingMustNotOverride() {
+        DI(allowSilentOverride = true) {
+            bind(tag = "name") { instance("Benjamin") }
+
+            assertFailsWith<DI.OverridingException> {
+                bind(tag = "name", overrides = false) { instance("Salomon") }
+            }
+        }
+    }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_14_Override.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_14_Override.kt
@@ -126,43 +126,159 @@ class Tests_14_Override {
     }
 
     @Test
-    fun test_09_DirectBindingExplicitOverride() {
+    fun test_09_SimpleBinding_ExplicitOverride() {
         val di = DI {
-            bind(tag = "name") { instance("Benjamin") }
-            bind(tag = "name", overrides = true) { instance("Salomon") }
+            bindInstance(tag = "name") { "Benjamin" }
+            bindInstance(tag = "name", overrides = true) { "Salomon" }
         }
 
         assertEquals("Salomon", di.direct.instance(tag = "name"))
     }
 
     @Test
-    fun test_10_DirectBindingSilentOverride() {
+    fun test_10_SimpleBinding_SilentOverride() {
         val di = DI(allowSilentOverride = true) {
-            bind(tag = "name") { instance("Benjamin") }
-            bind(tag = "name") { instance("Salomon") }
+            bindInstance(tag = "name") { "Benjamin" }
+            bindInstance(tag = "name") { "Salomon" }
         }
 
         assertEquals("Salomon", di.direct.instance(tag = "name"))
     }
 
     @Test
-    fun test_11_DirectBindingSilentOverrideNotAllowed() {
+    fun test_11_SimpleBinding_SilentOverrideNotAllowed() {
         DI {
-            bind(tag = "name") { instance("Benjamin") }
+            bindInstance(tag = "name") { "Benjamin" }
 
             assertFailsWith<DI.OverridingException> {
-                bind(tag = "name") { instance("Salomon") }
+                bindInstance(tag = "name") { "Salomon" }
             }
         }
     }
 
     @Test
-    fun test_12_DirectBindingMustNotOverride() {
+    fun test_12_SimpleBinding_MustNotOverride() {
         DI(allowSilentOverride = true) {
-            bind(tag = "name") { instance("Benjamin") }
+            bindInstance(tag = "name") { "Benjamin" }
 
             assertFailsWith<DI.OverridingException> {
-                bind(tag = "name", overrides = false) { instance("Salomon") }
+                bindInstance(tag = "name", overrides = false) { "Salomon" }
+            }
+        }
+    }
+
+    @Test
+    fun test_13_SimpleBinding__ExplicitOverride() {
+        val di = DI {
+            bindInstance(tag = "name") { "Benjamin" }
+            bindInstance(tag = "name", overrides = true) { "Salomon" }
+        }
+
+        assertEquals("Salomon", di.direct.instance(tag = "name"))
+    }
+
+    @Test
+    fun test_14_SimpleBinding_SilentOverride() {
+        val di = DI(allowSilentOverride = true) {
+            bindInstance(tag = "name") { "Benjamin" }
+            bindInstance(tag = "name") { "Salomon" }
+        }
+
+        assertEquals("Salomon", di.direct.instance(tag = "name"))
+    }
+
+    @Test
+    fun test_15_SimpleBinding_SilentOverrideNotAllowed() {
+        DI {
+            bindInstance(tag = "name") { "Benjamin" }
+
+            assertFailsWith<DI.OverridingException> {
+                bindInstance(tag = "name") { "Salomon" }
+            }
+        }
+    }
+
+    @Test
+    fun test_16_SimpleBinding_MustNotOverride() {
+        DI(allowSilentOverride = true) {
+            bindInstance(tag = "name") { "Benjamin" }
+
+            assertFailsWith<DI.OverridingException> {
+                bindInstance(tag = "name", overrides = false) { "Salomon" }
+            }
+        }
+    }
+
+    @Test
+    fun test_17_SimpleBinding_OverrideWithSuper() {
+        val di = DI(allowSilentOverride = true) {
+            bindInstance(tag = "name") { "Salomon" }
+            bind(tag = "name", overrides = true) { singleton { (overriddenInstance() as String) + " BRYS" } }
+            bind(tag = "name", overrides = true) { singleton { (overriddenInstance() as String) + " of France" } }
+        }
+
+        assertEquals("Salomon BRYS of France", di.direct.instance("name"))
+    }
+
+    @Test
+    fun test_18_DirectBinding_DependencyLoopWithOverrides() {
+
+        val di = DI {
+            bind(tag = "name") { singleton { instance<String>(tag = "title") + " Salomon " } }
+            bind(tag = "name", overrides = true) { singleton { (overriddenInstance() as String) + " BRYS " } }
+            bind(tag = "name", overrides = true) { singleton { (overriddenInstance() as String) + " of France" } }
+            bind(tag = "title") { singleton { instance<String>(tag = "name") + " the great" } }
+
+        }
+
+        assertFailsWith<DI.DependencyLoopException> {
+            @Suppress("UNUSED_VARIABLE")
+            di.direct.instance<String>(tag = "name")
+        }
+    }
+
+    @Test
+    fun test_19_SimpleBinding_ModuleOverride() {
+        val module = DI.Module("test") {
+            bindInstance(tag = "name", overrides = true) { "Salomon" }
+        }
+
+        val di = DI {
+            bindInstance(tag = "name") { "Benjamin" }
+            import(module, allowOverride = true)
+        }
+
+        assertEquals("Salomon", di.direct.instance(tag = "name"))
+    }
+
+    @Test
+    fun test_20_SimpleBinding_ModuleForbiddenOverride() {
+        val module = DI.Module("test") {
+            bindInstance(tag = "name", overrides = true) { "Salomon" }
+        }
+
+        DI {
+            bindInstance(tag = "name") { "Benjamin" }
+
+            assertFailsWith<DI.OverridingException> {
+                import(module)
+            }
+        }
+    }
+
+    @Test
+    fun test_21_SimpleBinding_ModuleImportsForbiddenOverride() {
+        val subModule = DI.Module("test1") {
+            bindInstance(tag = "name", overrides = true) { "Salomon" }
+        }
+
+        val module = DI.Module("test2") { import(subModule, allowOverride = true) }
+
+        DI {
+            bindInstance(tag = "name") { "Benjamin" }
+
+            assertFailsWith<DI.OverridingException> {
+                import(module)
             }
         }
     }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_15_OnReady.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_15_OnReady.kt
@@ -25,4 +25,19 @@ class Tests_15_OnReady {
         assertTrue(passed)
     }
 
+    @Test
+    fun test_00_SimpleBinding_OnReadyCallback() {
+        var passed = false
+
+        DI {
+            constant(tag = "name") with "Salomon"
+            bindSingleton { Person(instance(tag = "name")) }
+            onReady {
+                assertEquals("Salomon", instance<Person>().name)
+                passed = true
+            }
+        }
+        assertTrue(passed)
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_16_Multiton.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_16_Multiton.kt
@@ -13,7 +13,7 @@ class Tests_16_Multiton {
 
     @Test
     fun test_00_Multiton() {
-        val di = DI { bind() from multiton { name: String -> Person(name) } }
+        val di = DI { bind { multiton { name: String -> Person(name) } } }
 
         val p1: Person by di.instance(arg = "Salomon")
         val p2: Person by di.instance(fArg = { "Salomon" })
@@ -55,7 +55,43 @@ class Tests_16_Multiton {
 
     @Test
     fun test_02_NonSyncedMultiton() {
-        val di = DI { bind() from multiton(sync = false) { name: String -> Person(name) } }
+        val di = DI { bind { multiton(sync = false) { name: String -> Person(name) } }}
+
+        val p1: Person by di.instance(arg = "Salomon")
+        val p2: Person by di.instance(fArg = { "Salomon" })
+        val p3: Person by di.instance(arg = "Laila")
+        val p4: Person by di.instance(fArg = { "Laila" })
+
+        assertSame(p1, p2)
+        assertSame(p3, p4)
+
+        assertNotSame(p1, p3)
+
+        assertEquals("Salomon", p1.name)
+        assertEquals("Laila", p3.name)
+    }
+
+    @Test
+    fun test_00_SimpleMultiton() {
+        val di = DI { bindMultiton { name: String -> Person(name) } }
+
+        val p1: Person by di.instance(arg = "Salomon")
+        val p2: Person by di.instance(fArg = { "Salomon" })
+        val p3: Person by di.instance(arg = "Laila")
+        val p4: Person by di.instance(fArg = { "Laila" })
+
+        assertSame(p1, p2)
+        assertSame(p3, p4)
+
+        assertNotSame(p1, p3)
+
+        assertEquals("Salomon", p1.name)
+        assertEquals("Laila", p3.name)
+    }
+
+    @Test
+    fun test_02_NonSyncedSimpleMultiton() {
+        val di = DI { bindMultiton(sync = false) { name: String -> Person(name) } }
 
         val p1: Person by di.instance(arg = "Salomon")
         val p2: Person by di.instance(fArg = { "Salomon" })

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_17_NewInstance.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_17_NewInstance.kt
@@ -35,4 +35,28 @@ class Tests_17_NewInstance {
         assertEquals("Laila", wedding.her.name)
     }
 
+    @Test
+    fun test_02_SimpleBinding_NewInstance() {
+        val di = DI {
+            bindSingleton(tag = "Author")  { Person("Salomon") }
+            bindSingleton(tag = "Spouse") { Person("Laila") }
+        }
+
+        val wedding by di.newInstance { Wedding(instance(tag = "Author"), instance(tag = "Spouse")) }
+        assertEquals("Salomon", wedding.him.name)
+        assertEquals("Laila", wedding.her.name)
+    }
+
+    @Test
+    fun test_03_SimpleBinding_DirectNewInstance() {
+        val di = DI.direct {
+            bindSingleton(tag = "Author") { Person("Salomon") }
+            bindSingleton(tag = "Spouse") { Person("Laila") }
+        }
+
+        val wedding = di.newInstance { Wedding(instance(tag = "Author"), instance(tag = "Spouse")) }
+        assertEquals("Salomon", wedding.him.name)
+        assertEquals("Laila", wedding.her.name)
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
@@ -1,6 +1,7 @@
 package org.kodein.di
 
 import org.kodein.di.test.*
+import org.kodein.type.generic
 import kotlin.test.*
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -54,4 +55,51 @@ class Tests_18_MultiBindings {
         assertEquals(Person("Laila"), persons["loulou"])
     }
 
+    @Test
+    fun test_02_SimpleMultiSet() {
+        val di = DI {
+            bindSet<IPerson>()
+
+            inSet<IPerson> { singleton { Person("Salomon") } }
+            inSet<IPerson> { provider { Person("Laila") } }
+
+            Bind<List<IPerson>>(erasedList<IPerson>()) with provider { Instance<Set<IPerson>>(erasedSet(), null).toList() }
+        }
+
+        val persons1: Set<IPerson> by di.Instance(erasedSet())
+
+        assertTrue(Person("Salomon") in persons1)
+        assertTrue(Person("Laila") in persons1)
+
+        val persons2: Set<IPerson> by di.Instance(erasedSet())
+
+        val salomon1 = persons1.first { it.name == "Salomon" }
+        val salomon2 = persons2.first { it.name == "Salomon" }
+
+        val laila1 = persons1.first { it.name == "Laila" }
+        val laila2 = persons2.first { it.name == "Laila" }
+
+        assertSame(salomon1, salomon2)
+        assertNotSame(laila1, laila2)
+
+        val list: List<IPerson> by di.Instance(erasedList())
+        assertEquals(persons1.toList(), list)
+    }
+
+    @Test
+    fun test_03_SimpleMultiMap() {
+        val di = DI {
+            bindSet<PersonEntry>()
+
+            inSet { singleton { "so" to Person("Salomon") } }
+            inSet { provider { "loulou" to Person("Laila") } }
+
+            Bind<Map<String, Person>>(erasedMap()) with provider { Instance<PersonEntries>(erasedSet(), null).toMap() }
+        }
+
+        val persons: Map<String, Person> = di.direct.Instance(erasedMap<String, Person>(), null)
+
+        assertEquals(Person("Salomon"), persons["so"])
+        assertEquals(Person("Laila"), persons["loulou"])
+    }
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
@@ -9,17 +9,12 @@ class Tests_18_MultiBindings {
     @Test
     fun test_00_MultiSet() {
         val di = DI {
-            bind { setBinding<IPerson>() }
+            bindSet<IPerson>()
 
             bind<IPerson>().inSet() with singleton { Person("Salomon") }
             bind<IPerson>().inSet() with provider { Person("Laila") }
 
-            Bind<List<IPerson>>(erasedList<IPerson>()) with provider {
-                Instance<Set<IPerson>>(
-                    erasedSet(),
-                    null
-                ).toList()
-            }
+            Bind<List<IPerson>>(erasedList<IPerson>()) with provider { Instance<Set<IPerson>>(erasedSet(), null).toList() }
         }
 
         val persons1: Set<IPerson> by di.Instance(erasedSet())
@@ -45,7 +40,7 @@ class Tests_18_MultiBindings {
     @Test
     fun test_01_MultiMap() {
         val di = DI {
-            bind { setBinding<PersonEntry>() }
+            bindSet<PersonEntry>()
 
             bind<PersonEntry>().inSet() with singleton { "so" to Person("Salomon") }
             bind<PersonEntry>().inSet() with provider { "loulou" to Person("Laila") }
@@ -53,7 +48,7 @@ class Tests_18_MultiBindings {
             Bind<Map<String, Person>>(erasedMap()) with provider { Instance<PersonEntries>(erasedSet(), null).toMap() }
         }
 
-        val persons: Map<String, Person> = di.direct.Instance(erasedMap(), null)
+        val persons: Map<String, Person> = di.direct.Instance(erasedMap<String, Person>(), null)
 
         assertEquals(Person("Salomon"), persons["so"])
         assertEquals(Person("Laila"), persons["loulou"])

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
@@ -15,15 +15,15 @@ class Tests_18_MultiBindings {
             bind<IPerson>().inSet() with singleton { Person("Salomon") }
             bind<IPerson>().inSet() with provider { Person("Laila") }
 
-            Bind<List<IPerson>>(erasedList<IPerson>()) with provider { Instance<Set<IPerson>>(erasedSet(), null).toList() }
+            bind<List<IPerson>>() with provider { instance<Set<IPerson>>().toList() }
         }
 
-        val persons1: Set<IPerson> by di.Instance(erasedSet())
+        val persons1: Set<IPerson> by di.instance()
 
         assertTrue(Person("Salomon") in persons1)
         assertTrue(Person("Laila") in persons1)
 
-        val persons2: Set<IPerson> by di.Instance(erasedSet())
+        val persons2: Set<IPerson> by di.instance()
 
         val salomon1 = persons1.first { it.name == "Salomon" }
         val salomon2 = persons2.first { it.name == "Salomon" }
@@ -34,7 +34,7 @@ class Tests_18_MultiBindings {
         assertSame(salomon1, salomon2)
         assertNotSame(laila1, laila2)
 
-        val list: List<IPerson> by di.Instance(erasedList())
+        val list: List<IPerson> by di.instance()
         assertEquals(persons1.toList(), list)
     }
 
@@ -46,32 +46,45 @@ class Tests_18_MultiBindings {
             bind<PersonEntry>().inSet() with singleton { "so" to Person("Salomon") }
             bind<PersonEntry>().inSet() with provider { "loulou" to Person("Laila") }
 
-            Bind<Map<String, Person>>(erasedMap()) with provider { Instance<PersonEntries>(erasedSet(), null).toMap() }
+            bind<Map<String, Person>>() with provider { instance<PersonEntries>().toMap() }
         }
 
-        val persons: Map<String, Person> = di.direct.Instance(erasedMap<String, Person>(), null)
+        val persons: Map<String, Person> = di.direct.instance()
 
         assertEquals(Person("Salomon"), persons["so"])
         assertEquals(Person("Laila"), persons["loulou"])
     }
 
     @Test
-    fun test_02_SimpleMultiSet() {
+    fun test_02_MultiSetWithArg() {
+        val di = DI {
+            bindArgSet<String, IPerson>()
+            bind<IPerson>().inSet() with multiton { lastName: String -> Person("Salomon $lastName") }
+            bind<IPerson>().inSet() with factory { lastName: String -> Person("Laila $lastName") }
+        }
+
+        val persons: Set<IPerson> by di.instance(arg = "BRYS")
+        assertTrue(Person("Salomon BRYS") in persons)
+        assertTrue(Person("Laila BRYS") in persons)
+    }
+
+    @Test
+    fun test_03_SimpleMultiSet() {
         val di = DI {
             bindSet<IPerson>()
 
             inSet<IPerson> { singleton { Person("Salomon") } }
             inSet<IPerson> { provider { Person("Laila") } }
 
-            Bind<List<IPerson>>(erasedList<IPerson>()) with provider { Instance<Set<IPerson>>(erasedSet(), null).toList() }
+            bind<List<IPerson>>() with provider { instance<Set<IPerson>>().toList() }
         }
 
-        val persons1: Set<IPerson> by di.Instance(erasedSet())
+        val persons1: Set<IPerson> by di.instance()
 
         assertTrue(Person("Salomon") in persons1)
         assertTrue(Person("Laila") in persons1)
 
-        val persons2: Set<IPerson> by di.Instance(erasedSet())
+        val persons2: Set<IPerson> by di.instance()
 
         val salomon1 = persons1.first { it.name == "Salomon" }
         val salomon2 = persons2.first { it.name == "Salomon" }
@@ -82,24 +95,38 @@ class Tests_18_MultiBindings {
         assertSame(salomon1, salomon2)
         assertNotSame(laila1, laila2)
 
-        val list: List<IPerson> by di.Instance(erasedList())
+        val list: List<IPerson> by di.instance()
         assertEquals(persons1.toList(), list)
     }
 
     @Test
-    fun test_03_SimpleMultiMap() {
+    fun test_04_SimpleMultiMap() {
         val di = DI {
             bindSet<PersonEntry>()
 
             inSet { singleton { "so" to Person("Salomon") } }
             inSet { provider { "loulou" to Person("Laila") } }
 
-            Bind<Map<String, Person>>(erasedMap()) with provider { Instance<PersonEntries>(erasedSet(), null).toMap() }
+            bind<Map<String, Person>>() with provider { instance<PersonEntries>().toMap() }
         }
 
-        val persons: Map<String, Person> = di.direct.Instance(erasedMap<String, Person>(), null)
+        val persons: Map<String, Person> = di.direct.instance()
 
         assertEquals(Person("Salomon"), persons["so"])
         assertEquals(Person("Laila"), persons["loulou"])
     }
+
+    @Test
+    fun test_05_SimpleMultiSetWithArg() {
+        val di = DI {
+            bindArgSet<String, IPerson>()
+            inSet<IPerson> { factory { lastName: String -> Person("Salomon $lastName") } }
+            inSet<IPerson> { factory { lastName: String -> Person("Laila $lastName") } }
+        }
+
+        val persons: Set<IPerson> by di.instance(arg = "BRYS")
+        assertTrue(Person("Salomon BRYS") in persons)
+        assertTrue(Person("Laila BRYS") in persons)
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_18_MultiBindings.kt
@@ -9,12 +9,17 @@ class Tests_18_MultiBindings {
     @Test
     fun test_00_MultiSet() {
         val di = DI {
-            bind() from setBinding<IPerson>()
+            bind { setBinding<IPerson>() }
 
             bind<IPerson>().inSet() with singleton { Person("Salomon") }
             bind<IPerson>().inSet() with provider { Person("Laila") }
 
-            Bind<List<IPerson>>(erasedList<IPerson>()) with provider { Instance<Set<IPerson>>(erasedSet(), null).toList() }
+            Bind<List<IPerson>>(erasedList<IPerson>()) with provider {
+                Instance<Set<IPerson>>(
+                    erasedSet(),
+                    null
+                ).toList()
+            }
         }
 
         val persons1: Set<IPerson> by di.Instance(erasedSet())
@@ -40,7 +45,7 @@ class Tests_18_MultiBindings {
     @Test
     fun test_01_MultiMap() {
         val di = DI {
-            bind() from setBinding<PersonEntry>()
+            bind { setBinding<PersonEntry>() }
 
             bind<PersonEntry>().inSet() with singleton { "so" to Person("Salomon") }
             bind<PersonEntry>().inSet() with provider { "loulou" to Person("Laila") }
@@ -48,7 +53,7 @@ class Tests_18_MultiBindings {
             Bind<Map<String, Person>>(erasedMap()) with provider { Instance<PersonEntries>(erasedSet(), null).toMap() }
         }
 
-        val persons: Map<String, Person> = di.direct.Instance(erasedMap<String, Person>(), null)
+        val persons: Map<String, Person> = di.direct.Instance(erasedMap(), null)
 
         assertEquals(Person("Salomon"), persons["so"])
         assertEquals(Person("Laila"), persons["loulou"])

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_19_Late.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_19_Late.kt
@@ -21,7 +21,7 @@ class Tests_19_Late {
         val test = LateInit()
 
         test.di = DI {
-            bind { instance("Salomon") }
+            bindInstance { "Salomon" }
         }
 
         assertEquals("Salomon", test.name)
@@ -43,7 +43,7 @@ class Tests_19_Late {
         val name: String by di.instance()
 
         di.baseDI = DI {
-            bind { instance("Salomon") }
+            bindInstance { "Salomon" }
         }
 
         assertEquals("Salomon", name)
@@ -69,7 +69,7 @@ class Tests_19_Late {
         val name: String by di.instance()
 
         base.baseDI = DI {
-            bind { instance("Salomon") }
+            bindInstance { "Salomon" }
         }
 
         trigger.trigger()

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_19_Late.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_19_Late.kt
@@ -21,7 +21,7 @@ class Tests_19_Late {
         val test = LateInit()
 
         test.di = DI {
-            bind() from instance("Salomon")
+            bind { instance("Salomon") }
         }
 
         assertEquals("Salomon", test.name)
@@ -43,7 +43,7 @@ class Tests_19_Late {
         val name: String by di.instance()
 
         di.baseDI = DI {
-            bind() from instance("Salomon")
+            bind { instance("Salomon") }
         }
 
         assertEquals("Salomon", name)
@@ -69,7 +69,7 @@ class Tests_19_Late {
         val name: String by di.instance()
 
         base.baseDI = DI {
-            bind() from instance("Salomon")
+            bind { instance("Salomon") }
         }
 
         trigger.trigger()

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_20_MultiArguments.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_20_MultiArguments.kt
@@ -126,5 +126,114 @@ class Tests_20_MultiArguments {
         assertEquals("Mr Salomon BRYS of Paris, France in Europe", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
         assertNull(factoryNull)
     }
-    
+
+    @Test
+    fun test_06_SimpleBinding_MultiArgumentsFactory() {
+        val kodein = DI {
+            bindFactory { p: Person -> FullName(p.firstName, p.lastName) }
+        }
+
+        val i: FullName by kodein.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val ni: FullName? by kodein.instanceOrNull(arg = Person(name = "Salomon"))
+        val nni: FullName? by kodein.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dni: FullName? = kodein.direct.instanceOrNull(arg = Person(name = "Salomon"))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val np: (() -> FullName)? by kodein.providerOrNull(arg = Person(name = "Salomon"))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(name = "Salomon"))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+
+        assertAllNull(ni, dni, np, dnp)
+        assertAllNotNull(nni, dnni, nnp, dnnp)
+
+        assertAllEqual(FullName("Salomon", "BRYS"), i, nni!!, di, dnni, p(), nnp!!(), dp(), dnnp!!())
+    }
+
+    @Test
+    fun test_07_SimpleBinding_MultiArgumentsMultiton() {
+        val kodein = DI {
+            bindMultiton { p: Person -> FullName(p.firstName, p.lastName) }
+        }
+
+        val i: FullName by kodein.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val ni: FullName? by kodein.instanceOrNull(arg = Person(name = "Salomon"))
+        val nni: FullName? by kodein.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val di: FullName = kodein.direct.instance(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dni: FullName? = kodein.direct.instanceOrNull(arg = Person(name = "Salomon"))
+        val dnni: FullName? = kodein.direct.instanceOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val p: () -> FullName by kodein.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val np: (() -> FullName)? by kodein.providerOrNull(arg = Person(name = "Salomon"))
+        val nnp: (() -> FullName)? by kodein.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dp: () -> FullName = kodein.direct.provider(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+        val dnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(name = "Salomon"))
+        val dnnp: (() -> FullName)? = kodein.direct.providerOrNull(arg = Person(firstName = "Salomon", lastName = "BRYS"))
+
+        assertAllNull(ni, dni, np, dnp)
+        assertAllNotNull(nni, dnni, nnp, dnnp)
+
+        assertAllEqual(FullName("Salomon", "BRYS"), i, nni!!, di, dnni, p(), nnp!!(), dp(), dnnp!!())
+    }
+
+    @Test
+    fun test_08_SimpleBinding_MultiArgumentsFactoryBadType() {
+        val kodein = DI {
+            bindFactory { p: Person -> FullName(p.firstName, p.lastName) }
+        }
+
+        assertFailsWith<DI.NotFoundException> {
+            @Suppress("UNUSED_VARIABLE")
+            val fullName: FullName = kodein.direct.instance(arg = org.kodein.di.test.Person("Salomon"))
+        }
+    }
+
+    @Test
+    fun test_09_SimpleBinding_BigMultiArgumentsFactories() {
+        val kodein = DI {
+            bindFactory { m: MultiArgElement -> m.toString() }
+        }
+
+        assertEquals("Mr Salomon", kodein.direct.instance(arg = MultiArgElement("Salomon")))
+        assertEquals("Mr Salomon BRYS", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", kodein.direct.instance(arg = MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
+    }
+
+    @Test
+    fun test_10_MultiArgumentsFactoryFunction() {
+        val kodein = DI {
+            bindFactory { m: MultiArgElement -> m.toString() }
+        }
+
+        val factory: (MultiArgElement) -> String by kodein.factory()
+        val factoryNull: ((Int) -> String)? by kodein.factoryOrNull()
+
+        assertEquals("Mr Salomon", factory(MultiArgElement("Salomon")))
+        assertEquals("Mr Salomon BRYS", factory(MultiArgElement("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", factory(MultiArgElement("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
+        assertNull(factoryNull)
+    }
+
+    @Test
+    fun test_11_MultiArgumentsFactoryDirectFunction() {
+        val kodein = DI.direct {
+            bindFactory { m: MultiArgElement -> m.toString() }
+        }
+
+        val factory: (MultiArgElement) -> String = kodein.factory()
+        val factoryNull: ((Int) -> String)? = kodein.factoryOrNull()
+
+        assertEquals("Mr Salomon", factory(MultiArgElement("Salomon")))
+        assertEquals("Mr Salomon BRYS", factory(MultiArgElement("Salomon", "BRYS")))
+        assertEquals("Mr Salomon BRYS of Paris", factory(MultiArgElement("Salomon", "BRYS", "Paris")))
+        assertEquals("Mr Salomon BRYS of Paris, France", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France")))
+        assertEquals("Mr Salomon BRYS of Paris, France in Europe", factory(MultiArgElement("Salomon", "BRYS", "Paris", "France", "Europe")))
+        assertNull(factoryNull)
+    }
+
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_21_Description.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_21_Description.kt
@@ -19,8 +19,8 @@ class Tests_21_Description {
                 tag = null
         )
 
-        assertEquals("bind<String>()", key.bindDescription)
-        assertEquals("bind<String>() with ? { ? }", key.description)
+        assertEquals("bind<String>", key.bindDescription)
+        assertEquals("bind<String> { ? { ? } }", key.description)
     }
 
     @Test
@@ -33,7 +33,7 @@ class Tests_21_Description {
         )
 
         assertEquals("bind<IntRange>(tag = \"tag\")", key.bindDescription)
-        assertEquals("bind<IntRange>(tag = \"tag\") with ?<String>().? { Pair<String, String> -> ? }", key.description)
+        assertEquals("bind<IntRange>(tag = \"tag\") { ?<String>().? { Pair<String, String> -> ? } }", key.description)
     }
 
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_22_Search.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_22_Search.kt
@@ -81,5 +81,77 @@ class Tests_22_Search {
         assertTrue(42 in values)
     }
 
+    @Test
+    fun test_03_SimpleBinding_SearchTagged() {
+        val di = DI {
+            bindProvider(tag = "foo") { "String-foo" }
+            bindProvider(tag = "bar") { "String-bar" }
+            bindProvider(tag = "foo") { 42 }
+            bindProvider(tag = "bar") { 21 }
+        }
+
+        val bindings = di.container.tree.findAllBindings {
+            +tag("foo")
+        }
+
+        assertEquals(2, bindings.size)
+
+        val values = bindings.map { (key, _) ->
+            @Suppress("UNCHECKED_CAST")
+            di.container.factory(key as DI.Key<Any, Unit, Any>, Any()).invoke(Unit)
+        }
+
+        assertTrue("String-foo" in values)
+        assertTrue(42 in values)
+    }
+
+    @Test
+    fun test_04_SimpleBinding_SearchArgument() {
+        val di = DI {
+            bindProvider { "String-foo" }
+            bindFactory { name: String -> "String-$name" }
+            bindProvider { 42 }
+            bindFactory { i: Int -> 21 + i }
+        }
+
+        val bindings = di.container.tree.findAllBindings {
+            +argument<Unit>()
+        }
+
+        assertEquals(2, bindings.size)
+
+        val values = bindings.map { (key, _) ->
+            @Suppress("UNCHECKED_CAST")
+            di.container.factory(key as DI.Key<Any, Unit, Any>, Any()).invoke(Unit)
+        }
+
+        assertTrue("String-foo" in values)
+        assertTrue(42 in values)
+    }
+
+    @Test
+    fun test_05_SimpleBinding_SearchContext() {
+        val di = DI {
+            bindProvider { "String-foo" }
+            bind { contexted<String>().provider { "String-$context" } }
+            bindProvider { 42 }
+            bind { contexted<String>().provider { 21 + context.length } }
+        }
+
+        val bindings = di.container.tree.findAllBindings {
+            +context<Any>()
+        }
+
+        assertEquals(2, bindings.size)
+
+        val values = bindings.map { (key, _) ->
+            @Suppress("UNCHECKED_CAST")
+            di.container.factory(key as DI.Key<Any, Any?, Any>, Any()).invoke(Unit)
+        }
+
+        assertTrue("String-foo" in values)
+        assertTrue(42 in values)
+    }
+
 
 }

--- a/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_23_Context.kt
+++ b/kodein-di/src/commonTest/kotlin/org/kodein/di/Tests_23_Context.kt
@@ -64,4 +64,49 @@ class Tests_23_Context {
             di.direct.instance<Test02Foo>(tag = "ko")
         }
     }
+
+    @Test
+    fun test_03_DirectBinding_lazyOnContext() {
+        val di = DI {
+            bind { contexted<String>().provider { "Salomon $context" } }
+        }
+
+        var contextRetrieved = false
+
+        val name: String by di.on { contextRetrieved = true ; "BRYS" } .instance()
+
+        assertFalse(contextRetrieved)
+        assertEquals("Salomon BRYS", name)
+        assertTrue(contextRetrieved)
+    }
+
+    @Test
+    fun test_04_DirectBinding_lazyKContext() {
+        val di = DI {
+            bind { contexted<String>().provider { "Salomon $context" } }
+        }
+
+        val t = T01(di)
+
+        assertFalse(t.contextRetrieved)
+        assertEquals("Salomon BRYS", t.name)
+        assertTrue(t.contextRetrieved)
+    }
+
+    @Test
+    fun test_05_DirectBinding_singletonEraseContext() {
+        val di = DI {
+            bindSingleton(tag = "ok") { Test02Foo(instance(tag = "ok")) }
+            bindProvider(tag = "ok") { Test02Bar(null) }
+
+            bindSingleton(tag = "ko") { Test02Foo(instance(tag = "ko")) }
+            bind(tag = "ko") { contexted<Test02Ctx>().provider { Test02Bar(context) } }
+        }
+
+        di.direct.instance<Test02Foo>(tag = "ok")
+
+        assertFailsWith<DI.NotFoundException> {
+            di.direct.instance<Test02Foo>(tag = "ko")
+        }
+    }
 }

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_01_Thread.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_01_Thread.kt
@@ -62,7 +62,9 @@ class ErasedJvmTests_01_Thread {
     // Only the JVM supports threads
     @Test
     fun test_02_threadMultiton() {
-        val kodein = DI { bind() from multiton(ref = threadLocal) { name: String -> Person(name) } }
+        val kodein = DI {
+            bind { multiton(ref = threadLocal) { name: String -> Person(name) } }
+        }
 
         lateinit var tp1: Person
         lateinit var tp3: Person

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_02_Weak.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_02_Weak.kt
@@ -33,7 +33,9 @@ class ErasedJvmTests_02_Weak {
     @Suppress("UNUSED_VALUE")
     @Test
     fun test_01_WeakMultiton() {
-        val kodein = DI { bind() from multiton(ref = weakReference) { name: String -> Person(name) } }
+        val kodein = DI {
+            bind { multiton(ref = weakReference) { name: String -> Person(name) } }
+        }
 
         var p1: Person? = kodein.direct.instance(arg = "Salomon")
         var p2: Person? = kodein.direct.instance(arg = "Salomon")

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_03_Description.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_03_Description.kt
@@ -33,13 +33,13 @@ class ErasedJvmTests_03_Description {
 
         val lines = di.container.tree.bindings.description().trim().lineSequence().map(String::trim).toList()
         assertEquals(7, lines.size)
-        assertTrue("bind<IPerson>() with provider { Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"thread-singleton\") with singleton(ref = threadLocal) { Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"singleton\") with singleton { Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"factory\") with factory { String -> Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"instance\") with instance ( Person )" in lines)
-        assertTrue("bind<String>(tag = \"scoped\") with scoped(ErasedJvmTests_03_Description.TestScope).singleton { String }" in lines)
-        assertTrue("bind<Int>(tag = \"answer\") with instance ( Int )" in lines)
+        assertTrue("bind<IPerson> { provider { Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"thread-singleton\") { singleton(ref = threadLocal) { Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"singleton\") { singleton { Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"factory\") { factory { String -> Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"instance\") { instance ( Person ) }" in lines)
+        assertTrue("bind<String>(tag = \"scoped\") { scoped(ErasedJvmTests_03_Description.TestScope).singleton { String } }" in lines)
+        assertTrue("bind<Int>(tag = \"answer\") { instance ( Int ) }" in lines)
     }
 
     // Only the JVM supports precise description
@@ -58,13 +58,13 @@ class ErasedJvmTests_03_Description {
 
         val lines = di.container.tree.bindings.fullDescription().trim().lineSequence().map(String::trim).toList()
         assertEquals(7, lines.size)
-        assertTrue("bind<org.kodein.di.test.IPerson>() with provider { org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"thread-singleton\") with singleton(ref = org.kodein.di.threadLocal) { org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"singleton\") with singleton { org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"factory\") with factory { kotlin.String -> org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"instance\") with instance ( org.kodein.di.test.Person )" in lines)
-        assertTrue("bind<kotlin.String>(tag = \"scoped\") with scoped(org.kodein.di.ErasedJvmTests_03_Description.TestScope).singleton { kotlin.String }" in lines)
-        assertTrue("bind<kotlin.Int>(tag = \"answer\") with instance ( kotlin.Int )" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson> { provider { org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"thread-singleton\") { singleton(ref = org.kodein.di.threadLocal) { org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"singleton\") { singleton { org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"factory\") { factory { kotlin.String -> org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"instance\") { instance ( org.kodein.di.test.Person ) }" in lines)
+        assertTrue("bind<kotlin.String>(tag = \"scoped\") { scoped(org.kodein.di.ErasedJvmTests_03_Description.TestScope).singleton { kotlin.String } }" in lines)
+        assertTrue("bind<kotlin.Int>(tag = \"answer\") { instance ( kotlin.Int ) }" in lines)
     }
 
     // Only the JVM supports precise description
@@ -137,8 +137,8 @@ class ErasedJvmTests_03_Description {
                 tag = null
         )
 
-        assertEquals("bind<kotlin.String>()", key.bindFullDescription)
-        assertEquals("bind<kotlin.String>() with ? { ? }", key.fullDescription)
+        assertEquals("bind<kotlin.String>", key.bindFullDescription)
+        assertEquals("bind<kotlin.String> { ? { ? } }", key.fullDescription)
     }
 
     // Only the JVM supports precise description
@@ -151,7 +151,7 @@ class ErasedJvmTests_03_Description {
         )
 
         assertEquals("bind<kotlin.ranges.IntRange>(tag = \"tag\")", key.bindFullDescription)
-        assertEquals("bind<kotlin.ranges.IntRange>(tag = \"tag\") with ?<kotlin.String>().? { kotlin.Pair<kotlin.String, kotlin.String> -> ? }", key.fullDescription)
+        assertEquals("bind<kotlin.ranges.IntRange>(tag = \"tag\") { ?<kotlin.String>().? { kotlin.Pair<kotlin.String, kotlin.String> -> ? } }", key.fullDescription)
     }
 
 }

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_05_ExternalSource.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_05_ExternalSource.kt
@@ -15,7 +15,7 @@ class ErasedJvmTests_05_ExternalSource {
     @Test
     fun test_00_ExternalSource() {
         val di = DI.direct {
-            bind(tag = "him") from singleton { Person("Salomon") }
+            bind(tag = "him") { singleton { Person("Salomon") } }
 
             val laila = Person("Laila")
             externalSources += ExternalSource { key ->

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_07_Error.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/ErasedJvmTests_07_Error.kt
@@ -24,10 +24,10 @@ class ErasedJvmTests_07_Error {
 
         assertEquals("""
 Dependency recursion:
-     bind<org.kodein.di.test.A>()
-    ╔╩>bind<org.kodein.di.test.B>()
-    ║  ╚>bind<org.kodein.di.test.C>()
-    ║    ╚>bind<org.kodein.di.test.A>()
+     bind<org.kodein.di.test.A>
+    ╔╩>bind<org.kodein.di.test.B>
+    ║  ╚>bind<org.kodein.di.test.C>
+    ║    ╚>bind<org.kodein.di.test.A>
     ╚══════╝
         """.trim(), ex.message?.trim()
         )
@@ -41,7 +41,7 @@ Dependency recursion:
             fullContainerTreeOnError = true
         }
 
-        assertEquals("No binding found for bind<org.kodein.di.test.Person>() with ? { ? }\nRegistered in this DI container:\n", assertFailsWith<DI.NotFoundException> { di.instance<Person>() }.message)
+        assertEquals("No binding found for bind<org.kodein.di.test.Person> { ? { ? } }\nRegistered in this DI container:\n", assertFailsWith<DI.NotFoundException> { di.instance<Person>() }.message)
     }
 
 

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_00_Factory.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_00_Factory.kt
@@ -12,7 +12,7 @@ class GenericJvmTests_00_Factory {
     fun test_00_FactoryBindingGetFactory() {
 
         val kodein = DI {
-            bind() from factory { name: String -> Person(name) }
+            bind { factory { name: String -> Person(name) } }
         }
 
         val p1: (String) -> Person by kodein.factory()

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_03_Instance.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_03_Instance.kt
@@ -14,7 +14,9 @@ class GenericJvmTests_03_Instance {
 
         val p = Person()
 
-        val kodein = DI { bind() from instance(p) }
+        val kodein = DI {
+            bind { instance(p) }
+        }
 
         val p1: Person by kodein.instance()
         val p2: Person by kodein.instance()

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_07_Error.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_07_Error.kt
@@ -21,10 +21,10 @@ class GenericJvmTests_07_Error {
 
         assertEquals("""
 Dependency recursion:
-     bind<A>()
-    ╔╩>bind<B>()
-    ║  ╚>bind<C>()
-    ║    ╚>bind<A>()
+     bind<A>
+    ╔╩>bind<B>
+    ║  ╚>bind<C>
+    ║    ╚>bind<A>
     ╚══════╝
             """.trim(), ex.message
         )
@@ -46,10 +46,10 @@ Dependency recursion:
 
         assertEquals("""
 Dependency recursion:
-     bind<org.kodein.di.test.A>()
-    ╔╩>bind<org.kodein.di.test.B>()
-    ║  ╚>bind<org.kodein.di.test.C>()
-    ║    ╚>bind<org.kodein.di.test.A>()
+     bind<org.kodein.di.test.A>
+    ╔╩>bind<org.kodein.di.test.B>
+    ║  ╚>bind<org.kodein.di.test.C>
+    ║    ╚>bind<org.kodein.di.test.A>
     ╚══════╝
         """.trim(), ex.message?.trim()
         )
@@ -68,10 +68,10 @@ Dependency recursion:
     @Test fun test_02_RecursiveDependencies() {
 
         val kodein = DI {
-            bind { provider { Recurs0(instance()) } }
-            bind { provider { RecursA(instance()) } }
-            bind { provider { RecursB(instance(tag = "yay")) } }
-            bind(tag = "yay") { provider { RecursC(instance()) } }
+            bindProvider { Recurs0(instance()) }
+            bindProvider { RecursA(instance()) }
+            bindProvider { RecursB(instance(tag = "yay")) }
+            bindProvider(tag = "yay") { RecursC(instance()) }
         }
 
         assertFailsWith<DI.DependencyLoopException> {
@@ -123,7 +123,7 @@ Dependency recursion:
             fullContainerTreeOnError = true
         }
 
-        assertEquals("No binding found for bind<org.kodein.di.test.Person>() with ? { ? }\nRegistered in this DI container:\n", assertFailsWith<DI.NotFoundException> { kodein.instance<Person>() }.message)
+        assertEquals("No binding found for bind<org.kodein.di.test.Person> { ? { ? } }\nRegistered in this DI container:\n", assertFailsWith<DI.NotFoundException> { kodein.instance<Person>() }.message)
     }
 
 
@@ -162,30 +162,5 @@ Dependency recursion:
         assertFailsWith<DI.NotFoundException> {
             kodein.factory<Int, Person>()
         }
-    }
-
-    @Test
-    fun test_09_BindFromUnit() {
-
-        fun unit(@Suppress("UNUSED_PARAMETER") i: Int = 42) {}
-
-        val kodein = DI.direct {
-            assertFailsWith<IllegalArgumentException> {
-                bind { factory { i: Int -> unit(i) } }
-            }
-            assertFailsWith<IllegalArgumentException> {
-                bind { provider { unit() } }
-            }
-            assertFailsWith<IllegalArgumentException> {
-                bind { instance(Unit) }
-            }
-            assertFailsWith<IllegalArgumentException> {
-                bind { singleton { unit() } }
-            }
-
-            bind<Unit>() with instance(unit())
-        }
-
-        assertSame(Unit, kodein.instance())
     }
 }

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_07_Error.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_07_Error.kt
@@ -68,10 +68,10 @@ Dependency recursion:
     @Test fun test_02_RecursiveDependencies() {
 
         val kodein = DI {
-            bind() from provider { Recurs0(instance()) }
-            bind() from provider { RecursA(instance()) }
-            bind() from provider { RecursB(instance(tag = "yay")) }
-            bind(tag = "yay") from provider { RecursC(instance()) }
+            bind { provider { Recurs0(instance()) } }
+            bind { provider { RecursA(instance()) } }
+            bind { provider { RecursB(instance(tag = "yay")) } }
+            bind(tag = "yay") { provider { RecursC(instance()) } }
         }
 
         assertFailsWith<DI.DependencyLoopException> {
@@ -171,16 +171,16 @@ Dependency recursion:
 
         val kodein = DI.direct {
             assertFailsWith<IllegalArgumentException> {
-                bind() from factory { i: Int -> unit(i) }
+                bind { factory { i: Int -> unit(i) } }
             }
             assertFailsWith<IllegalArgumentException> {
-                bind() from provider { unit() }
+                bind { provider { unit() } }
             }
             assertFailsWith<IllegalArgumentException> {
-                bind() from instance(Unit)
+                bind { instance(Unit) }
             }
             assertFailsWith<IllegalArgumentException> {
-                bind() from singleton { unit() }
+                bind { singleton { unit() } }
             }
 
             bind<Unit>() with instance(unit())

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_13_Scope.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_13_Scope.kt
@@ -145,7 +145,7 @@ class GenericJvmTests_13_Scope {
         }
 
         val kodein = DI {
-            bind() from scoped(testScope).singleton { Person(context.name) }
+            bind { scoped(testScope).singleton { Person(context.name) } }
         }
 
         val test1 = T05(kodein, "one")
@@ -213,9 +213,9 @@ class GenericJvmTests_13_Scope {
     @Test
     fun test_08_CircularScopes() {
         val kodein = DI.direct {
-            bind() from contexted<A>().provider { context.str }
-            bind() from contexted<B>().provider { context.int }
-            bind() from contexted<C>().provider { context.char }
+            bind { contexted<A>().provider { context.str } }
+            bind { contexted<B>().provider { context.int } }
+            bind { contexted<C>().provider { context.char } }
             registerContextTranslator { a: A -> a.b }
             registerContextTranslator { b: B -> b.c }
             registerContextTranslator { c: C -> c.a }
@@ -269,7 +269,7 @@ class GenericJvmTests_13_Scope {
     @Test
     fun test_10_ContextTranslatorAndReceiver() {
         val kodein = DI.direct {
-            bind() from contexted<Name>().provider { FullName(context.firstName, "BRYS") }
+            bind { contexted<Name>().provider { FullName(context.firstName, "BRYS") } }
             registerContextFinder { Name("Salomon") }
             registerContextTranslator { name: String -> Name(name) }
         }

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_16_Multiton.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_16_Multiton.kt
@@ -13,7 +13,9 @@ class GenericJvmTests_16_Multiton {
 
     @Test
     fun test_00_Multiton() {
-        val kodein = DI { bind() from multiton { name: String -> Person(name) } }
+        val kodein = DI {
+            bind { multiton { name: String -> Person(name) } }
+        }
 
         val p1: Person by kodein.instance(arg = "Salomon")
         val p2: Person by kodein.instance(fArg = { "Salomon" })
@@ -55,7 +57,9 @@ class GenericJvmTests_16_Multiton {
 
     @Test
     fun test_02_NonSyncedMultiton() {
-        val kodein = DI { bind() from multiton(sync = false) { name: String -> Person(name) } }
+        val kodein = DI {
+            bind { multiton(sync = false) { name: String -> Person(name) } }
+        }
 
         val p1: Person by kodein.instance(arg = "Salomon")
         val p2: Person by kodein.instance(fArg = { "Salomon" })

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_18_MultiBindings.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_18_MultiBindings.kt
@@ -9,7 +9,7 @@ class GenericJvmTests_18_MultiBindings {
     @Test
     fun test_00_MultiSet() {
         val kodein = DI {
-            bind() from setBinding<IPerson>()
+            bind { setBinding<IPerson>() }
 
             bind<IPerson>().inSet() with singleton { Person("Salomon") }
             bind<IPerson>().inSet() with provider { Person("Laila") }
@@ -40,7 +40,7 @@ class GenericJvmTests_18_MultiBindings {
     @Test
     fun test_01_MultiMap() {
         val kodein = DI {
-            bind() from setBinding<PersonEntry>()
+            bind { setBinding<PersonEntry>() }
 
             bind<PersonEntry>().inSet() with singleton { "so" to Person("Salomon") }
             bind<PersonEntry>().inSet() with provider { "loulou" to Person("Laila") }

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_18_MultiBindings.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_18_MultiBindings.kt
@@ -9,7 +9,7 @@ class GenericJvmTests_18_MultiBindings {
     @Test
     fun test_00_MultiSet() {
         val kodein = DI {
-            bind { setBinding<IPerson>() }
+            bindSet<IPerson>()
 
             bind<IPerson>().inSet() with singleton { Person("Salomon") }
             bind<IPerson>().inSet() with provider { Person("Laila") }
@@ -40,7 +40,7 @@ class GenericJvmTests_18_MultiBindings {
     @Test
     fun test_01_MultiMap() {
         val kodein = DI {
-            bind { setBinding<PersonEntry>() }
+            bindSet<PersonEntry>()
 
             bind<PersonEntry>().inSet() with singleton { "so" to Person("Salomon") }
             bind<PersonEntry>().inSet() with provider { "loulou" to Person("Laila") }

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_19_Late.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_19_Late.kt
@@ -21,7 +21,7 @@ class GenericJvmTests_19_Late {
         val test = LateInit()
 
         test.di = DI {
-            bind() from instance("Salomon")
+            bind { instance("Salomon") }
         }
 
         assertEquals("Salomon", test.name)
@@ -43,7 +43,7 @@ class GenericJvmTests_19_Late {
         val name: String by di.instance()
 
         di.baseDI = DI {
-            bind() from instance("Salomon")
+            bind { instance("Salomon") }
         }
 
         assertEquals("Salomon", name)
@@ -69,7 +69,7 @@ class GenericJvmTests_19_Late {
         val name: String by di.instance()
 
         base.baseDI = DI {
-            bind() from instance("Salomon")
+            bind { instance("Salomon") }
         }
 
         trigger.trigger()

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_21_Description.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_21_Description.kt
@@ -22,8 +22,8 @@ class GenericJvmTests_21_Description {
                 tag = null
         )
 
-        assertEquals("bind<String>()", key.bindDescription)
-        assertEquals("bind<String>() with ? { ? }", key.description)
+        assertEquals("bind<String>", key.bindDescription)
+        assertEquals("bind<String> { ? { ? } }", key.description)
     }
 
     @Test
@@ -35,8 +35,8 @@ class GenericJvmTests_21_Description {
                 tag = null
         )
 
-        assertEquals("bind<kotlin.String>()", key.bindFullDescription)
-        assertEquals("bind<kotlin.String>() with ? { ? }", key.fullDescription)
+        assertEquals("bind<kotlin.String>", key.bindFullDescription)
+        assertEquals("bind<kotlin.String> { ? { ? } }", key.fullDescription)
     }
 
     private data class MultiArgs(val s1: String, val s2: String)
@@ -51,7 +51,7 @@ class GenericJvmTests_21_Description {
         )
 
         assertEquals("bind<IntRange>(tag = \"tag\")", key.bindDescription)
-        assertEquals("bind<IntRange>(tag = \"tag\") with ?<String>().? { GenericJvmTests_21_Description.MultiArgs -> ? }", key.description)
+        assertEquals("bind<IntRange>(tag = \"tag\") { ?<String>().? { GenericJvmTests_21_Description.MultiArgs -> ? } }", key.description)
     }
 
     @Test
@@ -64,7 +64,7 @@ class GenericJvmTests_21_Description {
         )
 
         assertEquals("bind<kotlin.ranges.IntRange>(tag = \"tag\")", key.bindFullDescription)
-        assertEquals("bind<kotlin.ranges.IntRange>(tag = \"tag\") with ?<kotlin.String>().? { org.kodein.di.GenericJvmTests_21_Description.MultiArgs -> ? }", key.fullDescription)
+        assertEquals("bind<kotlin.ranges.IntRange>(tag = \"tag\") { ?<kotlin.String>().? { org.kodein.di.GenericJvmTests_21_Description.MultiArgs -> ? } }", key.fullDescription)
     }
 
     object TestScope : UnboundedScope()
@@ -84,13 +84,13 @@ class GenericJvmTests_21_Description {
 
         val lines = kodein.container.tree.bindings.description().trim().lineSequence().map(String::trim).toList()
         assertEquals(7, lines.size)
-        assertTrue("bind<IPerson>() with provider { Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"thread-singleton\") with singleton(ref = threadLocal) { Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"singleton\") with singleton { Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"factory\") with factory { String -> Person }" in lines)
-        assertTrue("bind<IPerson>(tag = \"instance\") with instance ( Person )" in lines)
-        assertTrue("bind<String>(tag = \"scoped\") with scoped(GenericJvmTests_21_Description.TestScope).singleton { String }" in lines)
-        assertTrue("bind<Int>(tag = \"answer\") with instance ( Int )" in lines)
+        assertTrue("bind<IPerson> { provider { Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"thread-singleton\") { singleton(ref = threadLocal) { Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"singleton\") { singleton { Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"factory\") { factory { String -> Person } }" in lines)
+        assertTrue("bind<IPerson>(tag = \"instance\") { instance ( Person ) }" in lines)
+        assertTrue("bind<String>(tag = \"scoped\") { scoped(GenericJvmTests_21_Description.TestScope).singleton { String } }" in lines)
+        assertTrue("bind<Int>(tag = \"answer\") { instance ( Int ) }" in lines)
     }
 
     @Test
@@ -108,13 +108,13 @@ class GenericJvmTests_21_Description {
 
         val lines = kodein.container.tree.bindings.fullDescription().trim().lineSequence().map(String::trim).toList()
         assertEquals(7, lines.size)
-        assertTrue("bind<org.kodein.di.test.IPerson>() with provider { org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"thread-singleton\") with singleton(ref = org.kodein.di.threadLocal) { org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"singleton\") with singleton { org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"factory\") with factory { kotlin.String -> org.kodein.di.test.Person }" in lines)
-        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"instance\") with instance ( org.kodein.di.test.Person )" in lines)
-        assertTrue("bind<kotlin.String>(tag = \"scoped\") with scoped(org.kodein.di.GenericJvmTests_21_Description.TestScope).singleton { kotlin.String }" in lines)
-        assertTrue("bind<kotlin.Int>(tag = \"answer\") with instance ( kotlin.Int )" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson> { provider { org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"thread-singleton\") { singleton(ref = org.kodein.di.threadLocal) { org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"singleton\") { singleton { org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"factory\") { factory { kotlin.String -> org.kodein.di.test.Person } }" in lines)
+        assertTrue("bind<org.kodein.di.test.IPerson>(tag = \"instance\") { instance ( org.kodein.di.test.Person ) }" in lines)
+        assertTrue("bind<kotlin.String>(tag = \"scoped\") { scoped(org.kodein.di.GenericJvmTests_21_Description.TestScope).singleton { kotlin.String } }" in lines)
+        assertTrue("bind<kotlin.Int>(tag = \"answer\") { instance ( kotlin.Int ) }" in lines)
     }
 
     @Test

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_81_Thread.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_81_Thread.kt
@@ -59,7 +59,9 @@ class GenericJvmTests_81_Thread {
 
     @Test
     fun test_02_threadMultiton() {
-        val kodein = DI { bind() from multiton(ref = threadLocal) { name: String -> Person(name) } }
+        val kodein = DI {
+            bind { multiton(ref = threadLocal) { name: String -> Person(name) } }
+        }
 
         lateinit var tp1: Person
         lateinit var tp3: Person

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_82_Weak.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_82_Weak.kt
@@ -31,7 +31,9 @@ class GenericJvmTests_82_Weak {
     @Suppress("UNUSED_VALUE")
     @Test
     fun test_01_WeakMultiton() {
-        val kodein = DI { bind() from multiton(ref = weakReference) { name: String -> Person(name) } }
+        val kodein = DI {
+            bind { multiton(ref = weakReference) { name: String -> Person(name) } }
+        }
 
         var p1: Person? = kodein.direct.instance(arg = "Salomon")
         var p2: Person? = kodein.direct.instance(arg = "Salomon")

--- a/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_85_ExternalSource.kt
+++ b/kodein-di/src/jvmTest/kotlin/org/kodein/di/GenericJvmTests_85_ExternalSource.kt
@@ -14,7 +14,7 @@ class GenericJvmTests_85_ExternalSource {
     @Test
     fun test_00_ExternalSource() {
         val kodein = DI.direct {
-            bind(tag = "him") from singleton { Person("Salomon") }
+            bind(tag = "him") { singleton { Person("Salomon") } }
 
             val laila = Person("Laila")
             externalSources += ExternalSource { key ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         maven(url = "https://raw.githubusercontent.com/Kodein-Framework/kodein-internal-gradle-plugin/mvn-repo")
     }
     dependencies {
-        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:6.1.0")
+        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:6.3.0")
     }
 }
 


### PR DESCRIPTION
- add direct binding function `bind(tag: Any?, overrides: Boolean?, createBinding: () -> DIBinding)`
- deprecate `DirectBinder.from`
- add straight binding functions
    - `bindFactory` / `bindProvider` / `bindSingleton` / `bindMultiton` / `bindInstance` / `bindConstant`
- tests
- documentation