### PR TITLE
Multiple enhancements for Compose.

### DIFF
--- a/framework/android/kodein-di-framework-android-core/src/main/java/org/kodein/di/android/closest.kt
+++ b/framework/android/kodein-di-framework-android-core/src/main/java/org/kodein/di/android/closest.kt
@@ -20,7 +20,9 @@ private fun closestDI(thisRef: Any?, rootContext: Context): DI {
         }
         context = if (context is ContextWrapper) context.baseContext else null
     }
-    return (rootContext.applicationContext as DIAware).di
+    val appContext = rootContext.applicationContext as? DIAware
+        ?: error("Trying to find closest DI, but no DI container was found at all. Your Application should be DIAware.")
+    return appContext.di
 }
 
 /**

--- a/framework/compose/kodein-di-framework-compose/build.gradle.kts
+++ b/framework/compose/kodein-di-framework-compose/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.compose") version "0.5.0-build245"
+    id("org.jetbrains.compose") version "0.5.0-build262"
     id("org.kodein.library.mpp-with-android")
 }
 

--- a/framework/compose/kodein-di-framework-compose/src/androidMain/kotlin/org/kodein/di/compose/androidContext.kt
+++ b/framework/compose/kodein-di-framework-compose/src/androidMain/kotlin/org/kodein/di/compose/androidContext.kt
@@ -1,11 +1,11 @@
 package org.kodein.di.compose
 
 import android.content.Context
-import android.content.ContextWrapper
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import org.kodein.di.DI
-import org.kodein.di.DIAware
 import org.kodein.di.android.closestDI
 
 /**
@@ -14,16 +14,27 @@ import org.kodein.di.android.closestDI
  * @throws [ClassCastException] if no [DI] container is declared in the parent [Context]s
  */
 @Composable
-public fun contextDI(): DI {
+public fun androidContextDI(): DI {
     val context = LocalContext.current
     val di by closestDI { context }
     return remember { di }
 }
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed to androidContextDI", ReplaceWith("androidContextDI()"))
+@Composable
+public fun contextDI(): DI = androidContextDI()
 
 /**
  * Attaches a [DI] container to the underlying [Composable] tree, using the [DI] container attached to the current [Context] (see [contextDI]).
  *
  * @param content underlying [Composable] tree that will be able to consume the [LocalDI] container
  */
+// Deprecated since 7.7.0
+@Suppress("DeprecatedCallableAddReplaceWith")
+@Deprecated("This is not necessary anymore as the DI container is automatically used if no local DI is defined")
 @Composable
-public fun withDI(content: @Composable () -> Unit) = CompositionLocalProvider(LocalDI provides contextDI()) { content() }
+public fun withDI(content: @Composable () -> Unit) = CompositionLocalProvider(LocalDI provides androidContextDI()) { content() }
+
+@Composable
+internal actual fun diFromAppContext(): DI = androidContextDI()

--- a/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/CompositionLocal.kt
+++ b/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/CompositionLocal.kt
@@ -14,7 +14,10 @@ import org.kodein.di.DI
  *
  * @throws [IllegalStateException] if no DI container is attached to the Composable tree
  */
-public val LocalDI: ProvidableCompositionLocal<DI> = compositionLocalOf { error("Missing DI container!") }
+internal val LocalDI: ProvidableCompositionLocal<DI?> = compositionLocalOf { null }
+
+@Composable
+internal expect fun diFromAppContext(): DI
 
 /**
  * Composable helper function to access the current DI container from the Composable tree (if there is one!)
@@ -22,4 +25,4 @@ public val LocalDI: ProvidableCompositionLocal<DI> = compositionLocalOf { error(
  * @throws [IllegalStateException] if no DI container is attached to the Composable tree
  */
 @Composable
-public fun localDI(): DI = LocalDI.current
+public fun localDI(): DI = LocalDI.current ?: diFromAppContext()

--- a/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/retrieving.kt
+++ b/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/retrieving.kt
@@ -16,9 +16,14 @@ import org.kodein.di.*
  * @throws DI.DependencyLoopException If the instance construction triggered a dependency loop.
  */
 @Composable
-public inline fun <reified T : Any> instance(tag: Any? = null): DIProperty<T> = with(LocalDI.current) {
+public inline fun <reified T : Any> rememberInstance(tag: Any? = null): DIProperty<T> = with(localDI()) {
     remember { instance(tag) }
 }
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed rememberInstance", ReplaceWith("rememberInstance(tag)"))
+@Composable
+public inline fun <reified T : Any> instance(tag: Any? = null): DIProperty<T> = rememberInstance(tag)
 
 /**
  * Gets an instance of [T] for the given type and tag, curried from a factory that takes an argument [A].
@@ -34,8 +39,31 @@ public inline fun <reified T : Any> instance(tag: Any? = null): DIProperty<T> = 
  * @throws DI.DependencyLoopException If the value construction triggered a dependency loop.
  */
 @Composable
-public inline fun <reified A : Any, reified T : Any> instance(tag: Any? = null, arg: A): DIProperty<T> = with(LocalDI.current) {
+public inline fun <reified A : Any, reified T : Any> rememberInstance(tag: Any? = null, arg: A): DIProperty<T> = with(localDI()) {
     remember { instance(tag, arg) }
+}
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed rememberInstance", ReplaceWith("rememberInstance(tag, arg)"))
+@Composable
+public inline fun <reified A : Any, reified T : Any> instance(tag: Any? = null, arg: A): DIProperty<T> = rememberInstance(tag, arg)
+
+/**
+ * Gets an instance of [T] for the given type and tag, curried from a factory that takes an argument [A].
+ *
+ * A & T generics will be preserved!
+ *
+ * @param A The type of argument the curried factory takes.
+ * @param T The type of object to retrieve.
+ * @param tag The bound tag, if any.
+ * @param fArg The argument that will be given to the factory when curried.
+ * @return An instance of [T].
+ * @throws DI.NotFoundException If no provider was found.
+ * @throws DI.DependencyLoopException If the value construction triggered a dependency loop.
+ */
+@Composable
+public inline fun <reified A : Any, reified T : Any> rememberInstance(tag: Any? = null, noinline fArg: () -> A): DIProperty<T> = with(localDI()) {
+    remember { instance(tag, fArg) }
 }
 
 /**
@@ -51,9 +79,14 @@ public inline fun <reified A : Any, reified T : Any> instance(tag: Any? = null, 
  * @throws DI.DependencyLoopException When calling the factory function, if the instance construction triggered a dependency loop.
  */
 @Composable
-public inline fun <reified A : Any, reified T : Any> factory(tag: Any? = null): DIProperty<(A) -> T> = with(LocalDI.current) {
+public inline fun <reified A : Any, reified T : Any> rememberFactory(tag: Any? = null): DIProperty<(A) -> T> = with(localDI()) {
     remember { factory(tag) }
 }
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed rememberFactory", ReplaceWith("rememberFactory(tag)"))
+@Composable
+public inline fun <reified A : Any, reified T : Any> factory(tag: Any? = null): DIProperty<(A) -> T> = rememberFactory(tag)
 
 /**
  * Gets a provider of `T` for the given type and tag.
@@ -67,9 +100,14 @@ public inline fun <reified A : Any, reified T : Any> factory(tag: Any? = null): 
  * @throws DI.DependencyLoopException When calling the provider function, if the instance construction triggered a dependency loop.
  */
 @Composable
-public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null): DIProperty<() -> T> = with(LocalDI.current) {
+public inline fun <reified T : Any> rememberProvider(tag: Any? = null): DIProperty<() -> T> = with(localDI()) {
     remember { provider(tag) }
 }
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed rememberProvider", ReplaceWith("rememberProvider(tag)"))
+@Composable
+public inline fun <reified T : Any> provider(tag: Any? = null): DIProperty<() -> T> = rememberProvider(tag)
 
 /**
  * Gets a provider of [T] for the given type and tag, curried from a factory that takes an argument [A].
@@ -85,9 +123,14 @@ public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null):
  * @throws DI.DependencyLoopException When calling the provider, if the value construction triggered a dependency loop.
  */
 @Composable
-public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null, arg: A): DIProperty<() -> T> = with(LocalDI.current) {
+public inline fun <reified A : Any, reified T : Any> rememberProvider(tag: Any? = null, arg: A): DIProperty<() -> T> = with(localDI()) {
     remember { provider(tag, arg) }
 }
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed rememberProvider", ReplaceWith("rememberProvider(tag, arg)"))
+@Composable
+public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null, arg: A): DIProperty<() -> T> = rememberProvider(tag, arg)
 
 /**
  * Gets a provider of [T] for the given type and tag, curried from a factory that takes an argument [A].
@@ -103,6 +146,11 @@ public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null, 
  * @throws DI.DependencyLoopException When calling the provider, if the value construction triggered a dependency loop.
  */
 @Composable
-public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null, noinline fArg: () -> A): DIProperty<() -> T> = with(LocalDI.current) {
+public inline fun <reified A : Any, reified T : Any> rememberProvider(tag: Any? = null, noinline fArg: () -> A): DIProperty<() -> T> = with(localDI()) {
     remember { provider(tag, fArg) }
 }
+
+// Deprecated since 7.7.0
+@Deprecated("Renamed rememberProvider", ReplaceWith("rememberProvider(tag, fArg)"))
+@Composable
+public inline fun <reified A : Any, reified T : Any> provider(tag: Any? = null, noinline fArg: () -> A): DIProperty<() -> T> = rememberProvider(tag, fArg)

--- a/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/subDI.kt
+++ b/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/subDI.kt
@@ -23,7 +23,7 @@ public fun subDI(
     allowSilentOverride: Boolean = false,
     copy: Copy = Copy.NonCached,
     diBuilder: DI.MainBuilder.() -> Unit,
-    content: @Composable() () -> Unit
+    content: @Composable () -> Unit
 ) {
     val di = org.kodein.di.subDI(parentDI, allowSilentOverride, copy) { diBuilder() }
     CompositionLocalProvider(LocalDI provides di) { content() }
@@ -45,5 +45,5 @@ public fun subDI(
     allowSilentOverride: Boolean = false,
     copy: Copy = Copy.NonCached,
     diBuilder: DI.MainBuilder.() -> Unit,
-    content: @Composable() () -> Unit
-): Unit = subDI(LocalDI.current, allowSilentOverride, copy, diBuilder, content)
+    content: @Composable () -> Unit
+): Unit = subDI(localDI(), allowSilentOverride, copy, diBuilder, content)

--- a/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/withDI.kt
+++ b/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/withDI.kt
@@ -2,7 +2,7 @@ package org.kodein.di.compose
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import org.kodein.di.DI
+import org.kodein.di.*
 
 /**
  * Attaches a [DI] container to the underlying [Composable] tree
@@ -33,3 +33,26 @@ public fun withDI(vararg diModules: DI.Module, content: @Composable () -> Unit):
 @Composable
 public fun withDI(di: DI, content: @Composable () -> Unit): Unit =
     CompositionLocalProvider(LocalDI provides di) { content() }
+
+/**
+ * Attaches a DI context to the underlying [Composable] tree
+ *
+ * @param context the [DIContext] representing the context type and value
+ * @param content underlying [Composable] tree that will be able to access this context
+ */
+@Suppress("FunctionName")
+@Composable
+public fun OnDIContext(context: DIContext<*>, content: @Composable () -> Unit) {
+    val di = localDI()
+    CompositionLocalProvider(LocalDI provides di.On(context)) { content() }
+}
+
+/**
+ * Attaches a DI context to the underlying [Composable] tree
+ *
+ * @param context the context value
+ * @param content underlying [Composable] tree that will be able to access this context
+ */
+@Composable
+public inline fun <reified C : Any> onDIContext(context: C, crossinline content: @Composable () -> Unit): Unit =
+    OnDIContext(diContext(context)) { content() }

--- a/framework/compose/kodein-di-framework-compose/src/jvmMain/kotlin/org/kodein/di/compose/jvmContext.kt
+++ b/framework/compose/kodein-di-framework-compose/src/jvmMain/kotlin/org/kodein/di/compose/jvmContext.kt
@@ -1,0 +1,6 @@
+package org.kodein.di.compose
+
+import org.kodein.di.DI
+
+
+internal actual fun diFromAppContext(): DI = error("Missing DI container!")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
         maven(url = "https://raw.githubusercontent.com/Kodein-Framework/kodein-internal-gradle-plugin/mvn-repo")
     }
     dependencies {
-        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:6.6.0")
+        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:6.7.1")
     }
 }
 


### PR DESCRIPTION
- DI from Android context is now automatic
- `contextDI` is now renamed `androidContextDI` (to differentiate between DI context & Android context)
- Updated Android `closestDI` to throw a meaningful exception when failing (rather than a non-semantic ClassCastException)
- `LocalDI` is now internal, `localDI` (which defers to android context DI when there is no DI in the compose tree) must be used instead.
- Compose `instance`, `provider` & `factory` retrieval functions are renamed `rememberInstance()`, `rememberProvider()` & `rememberFactory()` (to align with every other compose function that uses `remember`).
- Added `onDIContext` to attach a DI context to a compose tree.