### PR TITLE
Fixed typo in the Android framework docs

### DIFF
--- a/doc/modules/framework/pages/android.adoc
+++ b/doc/modules/framework/pages/android.adoc
@@ -162,7 +162,7 @@ class MyActivity : AppCompatActivity(), DIAware {
     private val viewModel: MyViewModel by viewModel()
 }
 
-class MyFragment : Fragment(), DIAWare {
+class MyFragment : Fragment(), DIAware {
     override val di: DI by closestDI()
     private val viewModel: MyViewModel by viewModel()
 }


### PR DESCRIPTION
Fixed a typo in the code block of the Android framework documentation. This is impacting version 7.8.0 and 7.7.0 of the documentation. 

You can find the typo here: https://docs.kodein.org/kodein-di/7.8/framework/android.html#_view_models