### PR TITLE
Fixing packages names for kodein-di-conf

### DIFF
--- a/doc/modules/extension/pages/configurable.adoc
+++ b/doc/modules/extension/pages/configurable.adoc
@@ -47,7 +47,7 @@ Then add the dependency:
 [source,groovy,subs="attributes"]
 ----
 dependencies {
-    implementation 'org.kodein.di:kodein-conf-di:{version}'
+    implementation 'org.kodein.di:kodein-di-conf:{version}'
 }
 ----
 
@@ -58,7 +58,7 @@ Add the dependency:
 &lt;dependencies&gt;
     &lt;dependency&gt;
         &lt;groupId&gt;org.kodein.di&lt;/groupId&gt;
-        &lt;artifactId&gt;kodein-di-jvm&lt;/artifactId&gt;
+        &lt;artifactId&gt;kodein-di-conf-jvm&lt;/artifactId&gt;
         &lt;version&gt;{version}&lt;/version&gt;
     &lt;/dependency&gt;
 &lt;/dependencies&gt;


### PR DESCRIPTION
While using the instructions, I noticed that the package name was wrong. Here is the corrected information for JVM projects.