### PR TITLE
Upgrade Ktor dependency from 3.3.2 to 3.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ cmp-navigation = "2.9.1"
 kotlinpoet = "2.2.0"
 ksp = "1.9.20-1.0.14"
 # Ktor
-ktor = "3.3.2"
+ktor = "3.4.0"
 # JxInject
 javax-inject = "1"
 # TornadoFX


### PR DESCRIPTION
Fixes #502 - NoSuchMethodError on Route.getParent() when using Ktor 3.4.0.

In Ktor 3.4.0, the Route interface now extends TreeLike<Route> which
provides the parent property through interface inheritance instead of
declaring it directly. This causes a binary incompatibility for code
compiled against Ktor 3.3.x. Recompiling against 3.4.0 resolves the
NoSuchMethodError at runtime.

https://claude.ai/code/session_011qM9kir34Ami25jZYV9FZ1