### PR TITLE
fix((#506): update KodeinViewModelScopedFactory and KodeinViewModelScopedSingleton to use generic types

### DIFF
--- a/framework/compose/kodein-di-framework-android-x-compose/src/main/kotlin/org/kodein/di/compose/android/KodeinViewModelScopedFactory.kt
+++ b/framework/compose/kodein-di-framework-android-x-compose/src/main/kotlin/org/kodein/di/compose/android/KodeinViewModelScopedFactory.kt
@@ -8,20 +8,48 @@ import org.kodein.di.direct
 import org.kodein.type.TypeToken
 import org.kodein.type.erased
 
-public class KodeinViewModelScopedFactory<A : Any>(
+@PublishedApi
+internal class KodeinViewModelScopedFactory<A : Any>(
     private val di: DI,
     private val argType: TypeToken<A>,
+    private val vmType: TypeToken<*>,
     private val arg: A,
     private val tag: String? = null,
 ) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
-            di.direct.Factory(argType, erased(modelClass), tag).invoke(arg)
+            di.direct.Factory(argType, vmType as TypeToken<T>, tag).invoke(arg)
 }
 
-public class KodeinViewModelScopedSingleton(
+@PublishedApi
+internal class KodeinViewModelScopedSingleton(
     private val di: DI,
+    private val vmType: TypeToken<*>,
     private val tag: String? = null,
 ) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+        di.direct.Instance(type = vmType as TypeToken<T>, tag = tag)
+}
+
+@Deprecated("Use rememberViewModel instead.", level = DeprecationLevel.WARNING)
+@Suppress("FunctionName")
+public fun KodeinViewModelScopedSingleton(
+    di: DI,
+    tag: String? = null,
+): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
         di.direct.Instance(type = erased(modelClass), tag = tag)
+}
+
+@Deprecated("Use rememberViewModel instead.", level = DeprecationLevel.WARNING)
+@Suppress("FunctionName")
+public fun <A : Any> KodeinViewModelScopedFactory(
+    di: DI,
+    argType: TypeToken<A>,
+    arg: A,
+    tag: String? = null,
+): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+        di.direct.Factory(argType, erased(modelClass), tag).invoke(arg)
 }

--- a/framework/compose/kodein-di-framework-android-x-compose/src/main/kotlin/org/kodein/di/compose/android/navigation/navGraphViewModel.kt
+++ b/framework/compose/kodein-di-framework-android-x-compose/src/main/kotlin/org/kodein/di/compose/android/navigation/navGraphViewModel.kt
@@ -8,9 +8,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import org.kodein.di.compose.localDI
-import org.kodein.di.compose.viewmodel.KodeinViewModelScopedFactory
-import org.kodein.di.compose.viewmodel.KodeinViewModelScopedSingleton
-import org.kodein.type.erased
+import org.kodein.di.compose.android.KodeinViewModelScopedFactory
+import org.kodein.di.compose.android.KodeinViewModelScopedSingleton
+import org.kodein.type.generic
 
 /**
  * Gets an instance of a [VM] as an android [ViewModel], scoped on a [NavGraph], for the given [tag].
@@ -32,7 +32,7 @@ public inline fun <reified VM : ViewModel> NavBackStackEntry.rememberNavGraphVie
         ViewModelLazy(
             viewModelClass = VM::class,
             storeProducer = { navHostController.getBackStackEntry(getParentId()).viewModelStore },
-            factoryProducer = { KodeinViewModelScopedSingleton(di = this, tag = tag) }
+            factoryProducer = { KodeinViewModelScopedSingleton(di = this, vmType = generic<VM>(), tag = tag) }
         )
     }
 }
@@ -61,7 +61,7 @@ public inline fun <reified VM : ViewModel> NavBackStackEntry.navGraphViewModel(
     remember(this@navGraphViewModel, di, tag) {
         val provider = ViewModelProvider(
             navHostController.getBackStackEntry(getParentId()).viewModelStore,
-            KodeinViewModelScopedSingleton(di = di, tag = tag)
+            KodeinViewModelScopedSingleton(di = di, vmType = generic<VM>(), tag = tag)
         )
         if (tag == null) {
             provider[VM::class.java]
@@ -99,7 +99,8 @@ public inline fun <reified A : Any, reified VM : ViewModel> NavBackStackEntry.re
             factoryProducer = {
                 KodeinViewModelScopedFactory(
                     di = di,
-                    argType = erased<A>(),
+                    argType = generic<A>(),
+                    vmType = generic<VM>(),
                     arg = arg,
                     tag = tag,
                 )
@@ -139,7 +140,8 @@ public inline fun <reified A : Any, reified VM : ViewModel> NavBackStackEntry.na
             navHostController.getBackStackEntry(getParentId()).viewModelStore,
             KodeinViewModelScopedFactory(
                 di = di,
-                argType = erased<A>(),
+                argType = generic<A>(),
+                vmType = generic<VM>(),
                 arg = arg,
                 tag = tag,
             )

--- a/framework/compose/kodein-di-framework-android-x-compose/src/main/kotlin/org/kodein/di/compose/android/viewModel.kt
+++ b/framework/compose/kodein-di-framework-android-x-compose/src/main/kotlin/org/kodein/di/compose/android/viewModel.kt
@@ -31,7 +31,7 @@ public inline fun <reified VM : ViewModel> rememberViewModel(
         ViewModelLazy(
             viewModelClass = VM::class,
             storeProducer = { viewModelStoreOwner.viewModelStore },
-            factoryProducer = { KodeinViewModelScopedSingleton(di = di, tag = tag) },
+            factoryProducer = { KodeinViewModelScopedSingleton(di = di, vmType = generic<VM>(), tag = tag) },
         )
     }
 }
@@ -63,7 +63,7 @@ public inline fun <reified VM : ViewModel> viewModel(
     remember {
         val provider = ViewModelProvider(
             viewModelStoreOwner,
-            KodeinViewModelScopedSingleton(di = di, tag = tag),
+            KodeinViewModelScopedSingleton(di = di, vmType = generic<VM>(), tag = tag),
         )
         if (tag == null) {
             provider[VM::class.java]
@@ -103,6 +103,7 @@ public inline fun <reified A : Any, reified VM : ViewModel> rememberViewModel(
                 KodeinViewModelScopedFactory(
                     di = di,
                     argType = generic<A>(),
+                    vmType = generic<VM>(),
                     arg = arg,
                     tag = tag,
                 )
@@ -142,7 +143,7 @@ public inline fun <reified A : Any, reified VM : ViewModel> viewModel(
     remember {
         val provider = ViewModelProvider(
             viewModelStoreOwner,
-            KodeinViewModelScopedFactory(di = di, argType = generic<A>(), arg = arg, tag = tag),
+            KodeinViewModelScopedFactory(di = di, argType = generic<A>(), vmType = generic<VM>(), arg = arg, tag = tag),
         )
         if (tag == null) {
             provider[VM::class.java]

--- a/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/viewmodel/KodeinViewModelScope.kt
+++ b/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/viewmodel/KodeinViewModelScope.kt
@@ -9,37 +9,48 @@ import org.kodein.type.TypeToken
 import org.kodein.type.erased
 import kotlin.reflect.KClass
 
-/**
- * Factory class for creating ViewModel instances using Kodein dependency injection.
- *
- * @param A The type of argument to be passed to the ViewModel constructor.
- * @property di The instance of the Kodein DI container.
- * @property argType The TypeToken of the argument type.
- * @property arg The argument value to be passed to the ViewModel constructor.
- * @property tag The optional tag to be used for resolving ViewModel instance from DI container.
- */
-public class KodeinViewModelScopedFactory<A : Any>(
+@PublishedApi
+internal class KodeinViewModelScopedFactory<A : Any>(
     private val di: DI,
     private val argType: TypeToken<A>,
+    private val vmType: TypeToken<*>,
     private val arg: A,
     private val tag: String? = null,
 ) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T =
-        di.direct.Factory(argType, erased(modelClass), tag).invoke(arg)
+        di.direct.Factory(argType, vmType as TypeToken<T>, tag).invoke(arg)
 }
 
-/**
- * Factory class used to create ViewModel instances with Kodein DI container
- * @param di The Kodein DI container instance
- * @param tag An optional tag to filter the bindings
- *
- * @throws DI.NotFoundException if ViewModel class binding is not found in the DI container
- * @see ViewModelProvider.Factory
- */
-public class KodeinViewModelScopedSingleton(
+@PublishedApi
+internal class KodeinViewModelScopedSingleton(
     private val di: DI,
+    private val vmType: TypeToken<*>,
     private val tag: String? = null,
 ) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T =
+        di.direct.Instance(type = vmType as TypeToken<T>, tag = tag)
+}
+
+@Deprecated("Use rememberViewModel instead.", level = DeprecationLevel.WARNING)
+@Suppress("FunctionName")
+public fun KodeinViewModelScopedSingleton(
+    di: DI,
+    tag: String? = null,
+): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T =
         di.direct.Instance(type = erased(modelClass), tag = tag)
+}
+
+@Deprecated("Use rememberViewModel instead.", level = DeprecationLevel.WARNING)
+@Suppress("FunctionName")
+public fun <A : Any> KodeinViewModelScopedFactory(
+    di: DI,
+    argType: TypeToken<A>,
+    arg: A,
+    tag: String? = null,
+): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T =
+        di.direct.Factory(argType, erased(modelClass), tag).invoke(arg)
 }

--- a/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/viewmodel/viewModel.kt
+++ b/framework/compose/kodein-di-framework-compose/src/commonMain/kotlin/org.kodein.di.compose/viewmodel/viewModel.kt
@@ -29,7 +29,7 @@ public inline fun <reified VM : ViewModel> rememberViewModel(
         ViewModelLazy(
             viewModelClass = VM::class,
             storeProducer = { viewModelStoreOwner.viewModelStore },
-            factoryProducer = { KodeinViewModelScopedSingleton(di = di, tag = tag) }
+            factoryProducer = { KodeinViewModelScopedSingleton(di = di, vmType = generic<VM>(), tag = tag) }
         )
     }
 }
@@ -63,6 +63,7 @@ public inline fun <reified A : Any, reified VM : ViewModel> rememberViewModel(
                 KodeinViewModelScopedFactory(
                     di = di,
                     argType = generic<A>(),
+                    vmType = generic<VM>(),
                     arg = arg,
                     tag = tag
                 )


### PR DESCRIPTION
This pull request refactors how ViewModel factories are created and used with Kodein DI in both Android and multiplatform Compose modules. The main focus is to ensure that the correct type information for ViewModels is passed explicitly, improving type safety and reliability. It also introduces deprecation warnings for older factory constructors and marks the main factory classes as internal.

**Key changes:**

### Type Safety and Factory Construction

* Both `KodeinViewModelScopedFactory` and `KodeinViewModelScopedSingleton` now require an explicit `vmType` (`TypeToken<*>`) parameter, ensuring the correct ViewModel type is used for DI resolution. Previous usage of `erased(modelClass)` is replaced with `generic<VM>()` for better type inference. [[1]](diffhunk://#diff-5ef990178895d1b21fa47a664d53b94c5fe30d35ff2978466b41ba9b0f214400L11-R55) [[2]](diffhunk://#diff-ab140d128ab8cf8de08e23934c99a426e56aec10730afd826bed92b1f8adf43fL12-R56)
* All usages of these factories in Compose utility functions (`rememberViewModel`, `viewModel`, and navigation-scoped ViewModel providers) have been updated to pass the explicit `vmType` parameter using `generic<VM>()`. [[1]](diffhunk://#diff-f60f5df3bae74d76ff85c13a0493ab86c2372f3b54a5f6839a8c273c342543e9L35-R35) [[2]](diffhunk://#diff-f60f5df3bae74d76ff85c13a0493ab86c2372f3b54a5f6839a8c273c342543e9L64-R64) [[3]](diffhunk://#diff-f60f5df3bae74d76ff85c13a0493ab86c2372f3b54a5f6839a8c273c342543e9L102-R103) [[4]](diffhunk://#diff-f60f5df3bae74d76ff85c13a0493ab86c2372f3b54a5f6839a8c273c342543e9L142-R144) [[5]](diffhunk://#diff-04dc21c08065a125ee302c97fe0a74468a4495e0695da276397a287cf4e842f3L34-R34) [[6]](diffhunk://#diff-04dc21c08065a125ee302c97fe0a74468a4495e0695da276397a287cf4e842f3L66-R66) [[7]](diffhunk://#diff-04dc21c08065a125ee302c97fe0a74468a4495e0695da276397a287cf4e842f3R106) [[8]](diffhunk://#diff-04dc21c08065a125ee302c97fe0a74468a4495e0695da276397a287cf4e842f3L145-R146) [[9]](diffhunk://#diff-4d5c82da1bfcbd1349a3cc9b59ed0cc5a919d418f0c093f26c1077689bc50705L32-R32) [[10]](diffhunk://#diff-4d5c82da1bfcbd1349a3cc9b59ed0cc5a919d418f0c093f26c1077689bc50705R66)

### API Visibility and Deprecation

* The main factory classes are now marked as `internal` and `@PublishedApi`, limiting their direct usage and encouraging use through the provided Compose helpers. [[1]](diffhunk://#diff-5ef990178895d1b21fa47a664d53b94c5fe30d35ff2978466b41ba9b0f214400L11-R55) [[2]](diffhunk://#diff-ab140d128ab8cf8de08e23934c99a426e56aec10730afd826bed92b1f8adf43fL12-R56)
* Deprecated versions of the old, public factory constructors are provided with warnings, guiding users to migrate to `rememberViewModel`. [[1]](diffhunk://#diff-5ef990178895d1b21fa47a664d53b94c5fe30d35ff2978466b41ba9b0f214400L11-R55) [[2]](diffhunk://#diff-ab140d128ab8cf8de08e23934c99a426e56aec10730afd826bed92b1f8adf43fL12-R56)

### Code Modernization

* Suppression annotations are added to clarify unchecked casts in factory implementations. [[1]](diffhunk://#diff-5ef990178895d1b21fa47a664d53b94c5fe30d35ff2978466b41ba9b0f214400L11-R55) [[2]](diffhunk://#diff-ab140d128ab8cf8de08e23934c99a426e56aec10730afd826bed92b1f8adf43fL12-R56)
* Outdated or verbose KDoc comments are removed to streamline the code.

### Imports and TypeToken Usage

* Imports are updated to use the correct package references and to switch from `erased` to `generic` for type tokens, aligning with the new type-safe approach.

---

These changes improve the reliability and clarity of ViewModel DI integration with Kodein in Compose projects, making the API safer and easier to use.