### PR TITLE
fix(#508): tolerate unresolvable member types during reflective injection

### DIFF
--- a/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/internal/JxInjectorContainer.kt
+++ b/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/internal/JxInjectorContainer.kt
@@ -138,6 +138,31 @@ internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
             }
     }
 
+    /**
+     * Returns the members produced by [accessor] (typically [Class.getDeclaredFields] or
+     * [Class.getDeclaredMethods]), or an empty array if resolving them throws a [LinkageError].
+     *
+     * `Class.getDeclaredMethods` / `getDeclaredFields` eagerly resolve the types referenced by every member's
+     * signature — on the JVM as well as on Android's ART. When a member references a type that is absent at
+     * runtime, for instance a platform class introduced in a newer API level than the device runs on, the
+     * whole enumeration throws a [NoClassDefFoundError], even if that member is not annotated with `@Inject`.
+     * Being lenient here lets injection keep working for the rest of the class hierarchy instead of failing
+     * entirely.
+     *
+     * The fallback is class-granular: the runtime resolves every member signature in a single call, so a
+     * class whose members cannot be enumerated is skipped as a whole. In the reported case the unresolvable
+     * type lives on a framework super-class that carries no `@Inject` members; were an `@Inject` member's own
+     * type genuinely missing, its injection would be silently skipped rather than reported.
+     *
+     * See [#508](https://github.com/kosi-libs/Kodein/issues/508).
+     */
+    private inline fun <reified M : AccessibleObject> declaredMembersOrEmpty(accessor: () -> Array<M>): Array<M> =
+        try {
+            accessor()
+        } catch (linkageError: LinkageError) {
+            emptyArray()
+        }
+
     private tailrec fun fillMembersSetters(cls: Class<*>, setters: MutableList<DirectDI.(Any) -> Any>) {
         if (cls == Any::class.java)
             return
@@ -155,7 +180,7 @@ internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
         }
 
         fillSetters(
-            members = cls.declaredFields,
+            members = declaredMembersOrEmpty { cls.declaredFields },
             elements = { arrayOf(FieldElement(this)) },
             call = { receiver, values -> set(receiver, values[0]) },
             setters = setters
@@ -169,7 +194,7 @@ internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
         }
 
         fillSetters(
-            members = cls.declaredMethods,
+            members = declaredMembersOrEmpty { cls.declaredMethods },
             elements = { (0 until parameterTypes.size).map { ParameterElement(this, it) }.toTypedArray() },
             call = { receiver, values -> invoke(receiver, *values) },
             setters = setters

--- a/kodein-di-jxinject-jvm/src/test/java/org/kodein/di/jxinject/InjectJvmTests_05_LenientReflection.java
+++ b/kodein-di-jxinject-jvm/src/test/java/org/kodein/di/jxinject/InjectJvmTests_05_LenientReflection.java
@@ -1,0 +1,157 @@
+package org.kodein.di.jxinject;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression test for <a href="https://github.com/kosi-libs/Kodein/issues/508">issue #508</a>.
+ *
+ * <p>Injecting into a {@code ComponentActivity} subclass crashed with a {@code NoClassDefFoundError} on
+ * Android devices whose API level is older than a type referenced by one of the Activity's members (for
+ * instance {@code android.app.PictureInPictureUiState}, added in API 31). {@link Class#getDeclaredMethods()}
+ * and {@link Class#getDeclaredFields()} eagerly resolve the types referenced by every member's signature,
+ * so a single unresolvable type makes the whole enumeration throw — even when the offending member is not
+ * annotated with {@code @Inject}.
+ *
+ * <p>The JVM resolves member signatures eagerly just like Android's ART, so these tests reproduce the
+ * failure with a class loader that refuses to resolve a "missing" type referenced by a superclass member.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class InjectJvmTests_05_LenientReflection {
+
+    /** Stand-in for a platform type that is absent at runtime on older devices. */
+    public static class Missing {}
+
+    /** Stand-in for a framework superclass exposing a method that references {@link Missing}. */
+    public static class PoisonedByMethod {
+        @SuppressWarnings("unused")
+        public void referencesMissingType(Missing missing) {}
+    }
+
+    /** Stand-in for a framework superclass exposing a field that references {@link Missing}. */
+    public static class PoisonedByField {
+        @SuppressWarnings("unused")
+        public Missing missing;
+    }
+
+    /** Stand-in for the user's Activity subclass carrying a valid {@code @Inject} member. */
+    public static class InjectableBelowPoisonedMethod extends PoisonedByMethod {
+        @Inject String firstname;
+    }
+
+    /** Stand-in for the user's Activity subclass carrying a valid {@code @Inject} member. */
+    public static class InjectableBelowPoisonedField extends PoisonedByField {
+        @Inject String firstname;
+    }
+
+    /**
+     * Class loader that defines the given classes itself — so their member signatures resolve through it —
+     * while refusing to resolve {@code blockedName}, simulating a type that is absent at runtime. Everything
+     * else is delegated to the parent.
+     */
+    private static final class MissingTypeClassLoader extends ClassLoader {
+        private final String blockedName;
+        private final List<String> localNames;
+
+        MissingTypeClassLoader(ClassLoader parent, String blockedName, String... localNames) {
+            super(parent);
+            this.blockedName = blockedName;
+            this.localNames = Arrays.asList(localNames);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                if (name.equals(blockedName))
+                    throw new ClassNotFoundException(name + " is not available at runtime");
+
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null && localNames.contains(name))
+                    loaded = defineLocally(name);
+                if (loaded == null)
+                    return super.loadClass(name, resolve);
+
+                if (resolve)
+                    resolveClass(loaded);
+                return loaded;
+            }
+        }
+
+        private Class<?> defineLocally(String name) throws ClassNotFoundException {
+            String resource = name.replace('.', '/') + ".class";
+            try (InputStream stream = getParent().getResourceAsStream(resource)) {
+                if (stream == null)
+                    throw new ClassNotFoundException(name);
+                byte[] bytes = stream.readAllBytes();
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (ClassNotFoundException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+
+    private static Object loadInjectableWithMissingSupertype(Class<?> injectableClass, Class<?> poisonedSupertype) throws Exception {
+        MissingTypeClassLoader loader = new MissingTypeClassLoader(
+                InjectJvmTests_05_LenientReflection.class.getClassLoader(),
+                Missing.class.getName(),
+                poisonedSupertype.getName(),
+                injectableClass.getName()
+        );
+        return loader.loadClass(injectableClass.getName())
+                .getDeclaredConstructor()
+                .newInstance();
+    }
+
+    private static void assertEnumeratingMembersThrows(Class<?> poisonedSupertype) {
+        try {
+            poisonedSupertype.getDeclaredMethods();
+            poisonedSupertype.getDeclaredFields();
+            fail("Expected enumerating the members of " + poisonedSupertype + " to throw NoClassDefFoundError");
+        } catch (NoClassDefFoundError expected) {
+            // exactly the failure reported in #508
+        }
+    }
+
+    @Test
+    public void test_00_InjectionSurvivesUnresolvableSuperclassMethod() throws Exception {
+        Object injectable = loadInjectableWithMissingSupertype(InjectableBelowPoisonedMethod.class, PoisonedByMethod.class);
+
+        // Sanity check: enumerating the poisoned superclass really does blow up, so this test exercises the
+        // same failure as issue #508 rather than a no-op.
+        assertEnumeratingMembersThrows(injectable.getClass().getSuperclass());
+
+        // Before the fix this call propagated the NoClassDefFoundError and injection failed entirely.
+        Jx.of(KodeinsKt.test0()).inject(injectable);
+
+        assertEquals("Salomon", readField(injectable, "firstname"));
+    }
+
+    @Test
+    public void test_01_InjectionSurvivesUnresolvableSuperclassField() throws Exception {
+        Object injectable = loadInjectableWithMissingSupertype(InjectableBelowPoisonedField.class, PoisonedByField.class);
+
+        assertEnumeratingMembersThrows(injectable.getClass().getSuperclass());
+
+        Jx.of(KodeinsKt.test0()).inject(injectable);
+
+        assertEquals("Salomon", readField(injectable, "firstname"));
+    }
+
+    private static Object readField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}


### PR DESCRIPTION
## Problem

Injecting into any subclass of `ComponentActivity` crashes with
`java.lang.NoClassDefFoundError: Failed resolution of: Landroid/app/PictureInPictureUiState`
on Android devices running below API 31. `PictureInPictureUiState` was introduced in API 31, and
the failure started appearing after upgrading `androidx.activity:activity` from `1.12.4` to `1.13.0`.

```
java.lang.NoClassDefFoundError: Failed resolution of: Landroid/app/PictureInPictureUiState;
    at java.lang.reflect.Executable.getParameterTypesInternal(...)
    at java.lang.reflect.Method.getParameterTypes(...)
    at java.lang.Class.getDeclaredMethods(...)
    at org.kodein.di.jxinject.internal.JxInjectorContainer.fillMembersSetters(...)
```

## Root cause

As diagnosed in #508, `fillMembersSetters` enumerates each class in the receiver's hierarchy with
`cls.declaredFields` and `cls.declaredMethods`. Both `Class.getDeclaredMethods()` and
`Class.getDeclaredFields()` **eagerly resolve the types referenced by every member's signature**. When
a member references a type that is absent at runtime — here a platform class from a newer API level than
the device provides — the whole enumeration throws `NoClassDefFoundError` before we can inspect any
individual member, even though the offending member is not annotated with `@Inject`.

The reporter confirmed `cls.declaredMethods` is the trigger and noted `cls.declaredFields` could fail the
same way under other circumstances. A Google engineer replying on the corresponding
[androidx issue](https://issuetracker.google.com/issues/492945630#comment4) advised that callers should be
more lenient about such resolution failures.

## Fix

Wrap both member enumerations in a small helper that returns an empty array if resolving the members throws
a `LinkageError` (the superclass of `NoClassDefFoundError`). This is a targeted catch — not a blind
`catch (Throwable)` — so genuine failures during injection still propagate. When a class's members cannot
be resolved, only that member set for that class is skipped; valid `@Inject` members elsewhere in the class
hierarchy are still injected.

Both `declaredFields` and `declaredMethods` are covered, since the reporter could not rule out the field path.

**Scope.** `newInstance()`'s constructor lookup (`cls.declaredConstructors`) resolves parameter types the same eager way, but it is intentionally left strict: it runs only on DI-constructed, user-controlled types and never walks a framework super-class, so it cannot hit the #508 pattern, and a constructor with a genuinely unresolvable parameter should still fail loudly.

## Testing

`getDeclaredMethods()` / `getDeclaredFields()` resolve member signatures eagerly on the JVM just as they do
on ART, so the failure is reproducible in a plain JVM unit test. `InjectJvmTests_05_LenientReflection` uses a
class loader that refuses to resolve a "missing" type referenced by a superclass member, mirroring a platform
class that is absent on older devices:

- `test_00` — the missing type is referenced by a **superclass method** (the exact `#508` scenario).
- `test_01` — the missing type is referenced by a **superclass field**.

Each test first asserts that enumerating the poisoned superclass really does throw `NoClassDefFoundError`
(so the test exercises the real failure and cannot silently become a no-op), then verifies that injection
completes and the valid `@Inject` member on the subclass is still injected. Both tests fail without this
change and pass with it; the existing `InjectJvmTests` continue to pass.

I don't have a physical <API 31 device in this environment — @morrisseyai, since you offered, on-device
confirmation against the original repro would be very welcome.

Closes #508

