### PR TITLE
fix(#508): handle NoClassDefFoundError during JSR-330 injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
-#### 7.30.0 (TBD)
+#### 7.33.0 (TBD)
+
+## What's Changed
+* **Fixed `NoClassDefFoundError` during JSR-330 injection** (#508):
+    * Injecting into a class whose hierarchy declares a member referencing a type absent at runtime no longer fails
+    * Notably affected any `ComponentActivity` subclass below API 31 since `androidx.activity` 1.13.0, which declares `onPictureInPictureUiStateChanged(android.app.PictureInPictureUiState)` (an API 31 type)
+    * Such a class level is now skipped and injection continues up the hierarchy; documented in the JSR-330 page
+    * The skip is reported as a `WARNING` on the `org.kodein.di.jxinject` `java.util.logging` logger (logcat tag `org.kodein.di.jxinject` on Android), silenceable with `org.kodein.di.jxinject.level = OFF`
+* Kotlin 2.4.0 / KIGP 9.2.0 / Kaverit 2.13.0 / Gradle 9.3.1 / Compose 1.10.3
+* Migrated the Android Compose namespace to the target API
+
+#### 7.32.0 (2026-03-25)
+
+## What's Changed
+* Fixed `KodeinViewModelScopedFactory` and `KodeinViewModelScopedSingleton` to use generic types (#506)
+* Brought back scope on `SetBinder` and `ArgSetBinder` (#504)
+
+#### 7.31.0 (2026-02-08)
+
+## What's Changed
+* Upgraded Ktor dependency from 3.3.2 to 3.4.0 (#503)
+
+#### 7.30.0 (2025-11-20)
 
 ## What's Changed
 * Fixed DSL receiver scope issue (#478): Applied `@DslMarker` to DSL receiver interfaces to prevent accidental calls to outer receiver methods

--- a/doc/modules/extension/pages/jsr330.adoc
+++ b/doc/modules/extension/pages/jsr330.adoc
@@ -17,6 +17,45 @@ CAUTION: Every-thing that is described here is *a lot less performant* than usin
          Kittens *will* die painfully if you do!
 
 
+[[hierarchy]]
+== What gets visited
+
+`inject` does not look at the receiver's class alone: it walks the *entire* class hierarchy up to `Object` and enumerates every declared field and method of each level, looking for those annotated with `@Inject`.
+
+Two consequences are worth knowing:
+
+- The cost grows with inheritance depth, including superclasses you do not own.
+- A class level whose members cannot be introspected is *skipped*, and injection continues with the rest of the hierarchy.
+  This happens when a member's signature references a type that is absent at run-time, whether or not that member is annotated with `@Inject`.
+  An `@Inject` member on such a level is not injected, and no exception is raised.
+
+The typical case is Android, where a framework class compiled against a recent SDK may reference a platform type that does not exist on the device's API level.
+
+Because the failure is precisely the inability to enumerate members, Kodein-DI cannot know whether the skipped level declared any `@Inject` member.
+It therefore logs a `WARNING` on the `org.kodein.di.jxinject` logger, using `java.util.logging`:
+
+[source]
+----
+WARNING: Could not introspect the methods of androidx.activity.ComponentActivity: any @Inject member it
+declares will NOT be injected. This usually means a member signature references a type that is absent at
+runtime.
+----
+
+On Android this reaches logcat as a `WARN` entry tagged `org.kodein.di.jxinject`.
+
+If the skipped level is a framework class you do not own, the warning is expected and there is nothing to fix; you can silence it through the standard `java.util.logging` configuration.
+
+[source,properties]
+.Example: silencing the warning
+----
+org.kodein.di.jxinject.level = OFF
+----
+
+CAUTION: On Android, do not use JSR-330 injection on framework components (`Activity`, `Fragment`, `Service`...).
+         Their hierarchy is deep and entirely outside of your control, so every injection pays to walk it and is subject to the behaviour described above.
+         Use Kodein-DI's standard retrieval instead (`by instance()`), which uses no member reflexivity at all: see xref:framework:android.adoc[Android].
+
+
 [[install]]
 == Install
 

--- a/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/internal/JxInjectorContainer.kt
+++ b/kodein-di-jxinject-jvm/src/main/kotlin/org/kodein/di/jxinject/internal/JxInjectorContainer.kt
@@ -7,10 +7,23 @@ import org.kodein.type.typeToken
 import java.lang.reflect.*
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
+import java.util.logging.Level
+import java.util.logging.Logger
 import javax.inject.Inject
 import javax.inject.Provider
 
 internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
+    internal companion object {
+        /**
+         * Deliberately a literal rather than this class' name: [JxInjectorContainer] is internal and its FQN is an
+         * implementation detail, whereas this name is documented for users to configure. It is also 22 characters, so
+         * Android's `AndroidHandler` uses it verbatim as the logcat tag (it truncates anything longer than 23).
+         */
+        private const val LOGGER_NAME: String = "org.kodein.di.jxinject"
+
+        private val logger: Logger = Logger.getLogger(LOGGER_NAME)
+    }
+
     internal class Qualifier(val cls: Class<out Annotation>, val tagProvider: (Annotation) -> Any)
 
     private val _qualifiers = qualifiers.associate { it.cls to it.tagProvider }
@@ -138,6 +151,29 @@ internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
             }
     }
 
+    /**
+     * Enumerating declared members eagerly resolves the types referenced by every member's signature, whether or not
+     * that member is annotated with [Inject]. A signature referencing a type that is absent at runtime therefore makes
+     * the whole enumeration fail. This happens on Android, where a class compiled against a recent SDK may reference a
+     * platform type that does not exist on an older device (see https://github.com/kosi-libs/Kodein/issues/508).
+     *
+     * Such a level is skipped and the walk up the hierarchy continues. Because the failure *is* the inability to
+     * enumerate, we cannot know whether the level declared any [Inject] member, so this is reported as a possibility
+     * rather than as a fact.
+     */
+    private inline fun <reified M> declaredMembersOrEmpty(cls: Class<*>, kind: String, members: () -> Array<M>): Array<M> =
+        try {
+            members()
+        } catch (error: LinkageError) {
+            logger.log(
+                Level.WARNING,
+                "Could not introspect the $kind of ${cls.name}: any @Inject member it declares will NOT be injected. " +
+                    "This usually means a member signature references a type that is absent at runtime.",
+                error
+            )
+            emptyArray()
+        }
+
     private tailrec fun fillMembersSetters(cls: Class<*>, setters: MutableList<DirectDI.(Any) -> Any>) {
         if (cls == Any::class.java)
             return
@@ -155,7 +191,7 @@ internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
         }
 
         fillSetters(
-            members = cls.declaredFields,
+            members = declaredMembersOrEmpty(cls, "fields") { cls.declaredFields },
             elements = { arrayOf(FieldElement(this)) },
             call = { receiver, values -> set(receiver, values[0]) },
             setters = setters
@@ -169,7 +205,7 @@ internal class JxInjectorContainer(qualifiers: Set<Qualifier>) {
         }
 
         fillSetters(
-            members = cls.declaredMethods,
+            members = declaredMembersOrEmpty(cls, "methods") { cls.declaredMethods },
             elements = { (0 until parameterTypes.size).map { ParameterElement(this, it) }.toTypedArray() },
             call = { receiver, values -> invoke(receiver, *values) },
             setters = setters

--- a/kodein-di-jxinject-jvm/src/test/java/org/kodein/di/jxinject/InjectJvmTests_05_LenientReflection.java
+++ b/kodein-di-jxinject-jvm/src/test/java/org/kodein/di/jxinject/InjectJvmTests_05_LenientReflection.java
@@ -1,0 +1,221 @@
+package org.kodein.di.jxinject;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Regression tests for https://github.com/kosi-libs/Kodein/issues/508
+ *
+ * On Android, an app compiles against a recent SDK but runs against the device's framework. A class
+ * introduced in API 31 such as {@code android.app.PictureInPictureUiState} is simply absent at runtime on an
+ * API 30 device. That is normally harmless, because ART only fails when such a method is actually executed.
+ * Reflection defeats that leniency: {@code getDeclaredMethods()} / {@code getDeclaredFields()} eagerly resolve
+ * the types in every member's signature, so a single unresolvable type makes the whole enumeration throw
+ * {@link NoClassDefFoundError} -- even for members that carry no {@code @Inject} annotation.
+ *
+ * Since androidx.activity 1.13.0, {@code ComponentActivity} declares
+ * {@code onPictureInPictureUiStateChanged(android.app.PictureInPictureUiState)} directly, so walking the
+ * superclass chain of any Activity hits exactly that.
+ *
+ * These tests reproduce the failure on a plain JVM with a class loader that refuses to resolve one type.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class InjectJvmTests_05_LenientReflection {
+
+    /** Loads {@code reloaded} classes itself, refuses to resolve {@code hidden}, delegates everything else. */
+    private static final class HidingClassLoader extends ClassLoader {
+        private final String hidden;
+        private final Set<String> reloaded;
+
+        HidingClassLoader(ClassLoader parent, String hidden, String... reloaded) {
+            super(parent);
+            this.hidden = hidden;
+            this.reloaded = new HashSet<>(Arrays.asList(reloaded));
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.equals(hidden))
+                throw new ClassNotFoundException(name + " does not exist at runtime (mimics an API level too low)");
+
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> cls = findLoadedClass(name);
+                if (cls == null) {
+                    if (reloaded.contains(name)) {
+                        byte[] bytes = readBytecode(name);
+                        cls = defineClass(name, bytes, 0, bytes.length);
+                    } else {
+                        cls = getParent().loadClass(name);
+                    }
+                }
+                if (resolve) resolveClass(cls);
+                return cls;
+            }
+        }
+
+        private byte[] readBytecode(String name) throws ClassNotFoundException {
+            String path = name.replace('.', '/') + ".class";
+            try (InputStream in = getParent().getResourceAsStream(path)) {
+                if (in == null) throw new ClassNotFoundException(name);
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buffer = new byte[8192];
+                int read;
+                while ((read = in.read(buffer)) != -1) out.write(buffer, 0, read);
+                return out.toByteArray();
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+
+    private static final String MISSING = "org.kodein.di.jxinject.LenientMissing";
+    private static final String METHOD_BASE = "org.kodein.di.jxinject.LenientMethodBase";
+    private static final String METHOD_SUB = "org.kodein.di.jxinject.LenientMethodSub";
+    private static final String FIELD_BASE = "org.kodein.di.jxinject.LenientFieldBase";
+    private static final String FIELD_SUB = "org.kodein.di.jxinject.LenientFieldSub";
+
+    private static Class<?> loadHiding(String name) throws Exception {
+        ClassLoader loader = new HidingClassLoader(
+                InjectJvmTests_05_LenientReflection.class.getClassLoader(),
+                MISSING,
+                METHOD_BASE, METHOD_SUB, FIELD_BASE, FIELD_SUB
+        );
+        return loader.loadClass(name);
+    }
+
+    /** These classes are package-private but loaded by another loader, so they land in a different runtime package. */
+    private static Object instantiate(String name) throws Exception {
+        Constructor<?> constructor = loadHiding(name).getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    private static Object readField(Object receiver, String name) throws Exception {
+        Field field = receiver.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(receiver);
+    }
+
+    /**
+     * Proves the harness is faithful: enumerating members of a class whose signature references an
+     * unresolvable type throws, exactly as ART does below API 31. If this test ever stops throwing, the two
+     * tests below are passing vacuously and prove nothing.
+     */
+    @Test
+    public void test_00_HarnessActuallyFailsToEnumerateMembers() throws Exception {
+        Class<?> methodBase = loadHiding(METHOD_BASE);
+        assertThrows(NoClassDefFoundError.class, methodBase::getDeclaredMethods);
+
+        Class<?> fieldBase = loadHiding(FIELD_BASE);
+        assertThrows(NoClassDefFoundError.class, fieldBase::getDeclaredFields);
+    }
+
+    /** The reported case: a superclass declares a non-@Inject method taking an absent type. */
+    @Test
+    public void test_01_InjectsDespiteUnresolvableSuperclassMethod() throws Exception {
+        Object receiver = instantiate(METHOD_SUB);
+
+        Jx.of(KodeinsKt.test0()).inject(receiver);
+
+        assertEquals("Salomon", readField(receiver, "firstname"));
+    }
+
+    /** The same hazard on the field enumeration path. */
+    @Test
+    public void test_02_InjectsDespiteUnresolvableSuperclassField() throws Exception {
+        Object receiver = instantiate(FIELD_SUB);
+
+        Jx.of(KodeinsKt.test0()).inject(receiver);
+
+        assertEquals("Salomon", readField(receiver, "firstname"));
+    }
+
+    /**
+     * Skipping a class level must not be silent: an @Inject member that is never injected leaves a null field with
+     * nothing pointing at Kodein, which is harder to diagnose than a crash.
+     */
+    @Test
+    public void test_03_WarnsWhenSkippingAClassLevel() throws Exception {
+        List<LogRecord> records = new ArrayList<>();
+        Handler capture = new Handler() {
+            @Override public void publish(LogRecord record) { records.add(record); }
+            @Override public void flush() {}
+            @Override public void close() {}
+        };
+
+        Logger logger = Logger.getLogger("org.kodein.di.jxinject");
+        logger.addHandler(capture);
+        try {
+            Object receiver = instantiate(METHOD_SUB);
+
+            Jx.of(KodeinsKt.test0()).inject(receiver);
+
+            // Logging must not have changed the outcome.
+            assertEquals("Salomon", readField(receiver, "firstname"));
+        } finally {
+            logger.removeHandler(capture);
+        }
+
+        assertEquals(1, records.size());
+        LogRecord record = records.get(0);
+        assertEquals(Level.WARNING, record.getLevel());
+        assertTrue(
+                "message should name the skipped class, was: " + record.getMessage(),
+                record.getMessage().contains(METHOD_BASE)
+        );
+        // The cause must travel as structured data, not be flattened into the message.
+        assertTrue(record.getThrown() instanceof NoClassDefFoundError);
+    }
+
+    /**
+     * The logger name is documented for users to configure, and Android derives the logcat tag from it, using it
+     * verbatim only while it stays within 23 characters. Both make it a compatibility surface, not an internal detail.
+     */
+    @Test
+    public void test_04_LoggerNameIsAUsableLogcatTag() {
+        assertTrue("org.kodein.di.jxinject".length() <= 23);
+    }
+}
+
+/** Stands in for {@code android.app.PictureInPictureUiState}: present at compile time, absent at runtime. */
+class LenientMissing {
+}
+
+/** Stands in for {@code androidx.activity.ComponentActivity}. Note: no {@code @Inject} anywhere. */
+class LenientMethodBase {
+    public void onSomethingUiStateChanged(LenientMissing state) {
+    }
+}
+
+class LenientMethodSub extends LenientMethodBase {
+    @Inject
+    String firstname;
+}
+
+class LenientFieldBase {
+    LenientMissing state;
+}
+
+class LenientFieldSub extends LenientFieldBase {
+    @Inject
+    String firstname;
+}


### PR DESCRIPTION
Skip class hierarchy levels that reference types absent at runtime, allowing injection to continue up the chain. Logs a WARNING when a level is skipped.

This fixes injection on Android devices where a compiled app may reference platform types that don't exist at runtime (e.g., ComponentActivity below API 31 referencing PictureInPictureUiState from androidx.activity 1.13.0+).